### PR TITLE
修改赤念果11线路中ID 10的type为传送

### DIFF
--- a/repo/pathing/赤念果/赤念果11.json
+++ b/repo/pathing/赤念果/赤念果11.json
@@ -87,7 +87,7 @@
       "y": -2465.373046875,
       "action": "",
       "move_mode": "walk",
-      "type": "path"
+      "type": "teleport"
     },
     {
       "id": 11,


### PR DESCRIPTION
原本应该为传送，如果是途径点的话，会导致角色在悬崖下卡死