### PR TITLE
修改赤念果11线路中ID 8，ID 10的type为传送

### DIFF
--- a/repo/pathing/赤念果/赤念果11.json
+++ b/repo/pathing/赤念果/赤念果11.json
@@ -71,7 +71,7 @@
       "y": -2465.39501953125,
       "action": "",
       "move_mode": "walk",
-      "type": "path"
+      "type": "teleport"
     },
     {
       "id": 9,
@@ -87,7 +87,7 @@
       "y": -2465.373046875,
       "action": "",
       "move_mode": "walk",
-      "type": "path"
+      "type": "teleport"
     },
     {
       "id": 11,

--- a/repo/pathing/赤念果/赤念果13.json
+++ b/repo/pathing/赤念果/赤念果13.json
@@ -2,10 +2,9 @@
   "info": {
     "name": "赤念果",
     "type": "collect",
-    "country": "须弥",
     "author": "½",
     "version": "",
-    "description": "需要纳西妲",
+    "description": "",
     "bgiVersion": "0.35.1"
   },
   "positions": [
@@ -29,8 +28,8 @@
       "id": 3,
       "x": 4796.865966796875,
       "y": -2800.109375,
-      "action": "",
-      "move_mode": "up_down_grab_leaf",
+      "action": "up_down_grab_leaf",
+      "move_mode": "walk",
       "type": "path"
     },
     {
@@ -59,6 +58,14 @@
     },
     {
       "id": 7,
+      "x": 4614.235839843749,
+      "y": -2788.8095703125,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "type": "path"
+    },
+    {
+      "id": 8,
       "x": 4598.78759765625,
       "y": -2781.18603515625,
       "action": "nahida_collect",

--- a/repo/pathing/赤念果/赤念果14.json
+++ b/repo/pathing/赤念果/赤念果14.json
@@ -2,10 +2,9 @@
   "info": {
     "name": "赤念果",
     "type": "collect",
-    "country": "须弥",
     "author": "½",
     "version": "",
-    "description": "需要纳西妲",
+    "description": "",
     "bgiVersion": "0.35.1"
   },
   "positions": [
@@ -70,7 +69,7 @@
       "x": 4221.429443359375,
       "y": -2304.44140625,
       "action": "",
-      "move_mode": "walk",
+      "move_mode": "climb",
       "type": "path"
     },
     {
@@ -78,7 +77,7 @@
       "x": 4214.169921875,
       "y": -2307.8271484375,
       "action": "",
-      "move_mode": "walk",
+      "move_mode": "climb",
       "type": "target"
     },
     {
@@ -86,7 +85,7 @@
       "x": 4203.718994140625,
       "y": -2302.1044921875,
       "action": "",
-      "move_mode": "walk",
+      "move_mode": "climb",
       "type": "target"
     },
     {


### PR DESCRIPTION
ID8原因：原本应该为传送，如果是途径点的话，会导致角色在悬崖下卡死
ID10原因：减少跑图时间