### PR TITLE
fix: 领取纪行奖励如果正好升级，sleep时间会过短，导致无法正常退出领奖界面

### DIFF
--- a/repo/js/BattlePass/main.js
+++ b/repo/js/BattlePass/main.js
@@ -5,8 +5,8 @@
     click(1920, 100);
     await sleep(1000);
     click(3480, 1948);
-    await sleep(1000);
+    await sleep(3000);
     keyPress("Escape");
 
-    log.info("已领取历练点");
+    log.info("已领取纪行奖励");
 })();

--- a/repo/js/BattlePass/manifest.json
+++ b/repo/js/BattlePass/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "领取纪行",
-  "version": "1.0",
+  "version": "1.1",
   "description": "用于领取纪行",
   "authors": [
     {


### PR DESCRIPTION
如题