### PR TITLE
完全退出游戏（键鼠版）

### DIFF
--- a/repo/js/ExitGame/main.js
+++ b/repo/js/ExitGame/main.js
@@ -1,0 +1,15 @@
+(async function () {
+    // settings 的对象内容来自于 settings.json 文件生成的动态配置页面
+//前置系统状态：大世界正常主界面
+	setGameMetrics(3840,2160,2)
+        keyPress("VK_ESCAPE");//打开派蒙菜单
+        await sleep(1000);
+	click(90,2000);//点击左下角退出按钮
+	await sleep(1000);
+	click(2100,1500);//点击确定
+	await sleep(10000);//渲染开门界面的时间
+	click(200,1950);//点击登录界面左下角退出按钮
+	await sleep(1000);
+	click(2200,1100);//点击确定
+	await sleep(1000);
+})();

--- a/repo/js/ExitGame/manifest.json
+++ b/repo/js/ExitGame/manifest.json
@@ -1,0 +1,13 @@
+{
+  "manifest_version": 1,
+  "name": "完全退出游戏",
+  "version": "1.0",
+  "description": "配合其他脚本使用。当其他任务完成之后，调用此脚本完成游戏退出（指结束游戏进程）",
+  "authors": [
+    {
+      "name": "Because",
+      "link": "https://github.com/Because66666"
+    }
+  ],
+  "main": "main.js"
+}


### PR DESCRIPTION
简要说明：使用键鼠在指定坐标点击，完全退出游戏
前置系统条件：处于大世界中。执行此脚本前不需要自行打开派蒙菜单。