### PR TITLE
遗迹守卫1.1

### DIFF
--- a/repo/pathing/遗迹守卫/遗迹守卫1.json
+++ b/repo/pathing/遗迹守卫/遗迹守卫1.json
@@ -1,0 +1,132 @@
+{
+  "info": {
+    "name": "遗迹守卫1",
+    "type": "collect",
+    "author": "XS",
+    "version": "1.1",
+    "description": "建议带盾芙芙万叶芭芭拉，因为点位特殊位移大的容易从平台掉下来",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 1045.5537109375,
+      "y": 950.6259765625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": 1011.8408203125,
+      "y": 942.2646484375,
+      "action": "",
+      "move_mode": "fly",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": 979.97265625,
+      "y": 844.142578125,
+      "action": "",
+      "move_mode": "fly",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": 973.60546875,
+      "y": 820.53564453125,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 5,
+      "x": 970.9951171875,
+      "y": 814.802734375,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 6,
+      "x": 955.55078125,
+      "y": 782.3154296875,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 7,
+      "x": 957.498046875,
+      "y": 781.80712890625,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 8,
+      "x": 957.4013671875,
+      "y": 779.53857421875,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 9,
+      "x": 955.2314453125,
+      "y": 781.53662109375,
+      "action": "fight",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 10,
+      "x": 967.205078125,
+      "y": 771.04248046875,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 11,
+      "x": 966.0302734375,
+      "y": 760.8203125,
+      "action": "",
+      "move_mode": "fly",
+      "type": "target"
+    },
+    {
+      "id": 12,
+      "x": 964.99609375,
+      "y": 758.39794921875,
+      "action": "",
+      "move_mode": "fly",
+      "type": "target"
+    },
+    {
+      "id": 13,
+      "x": 969.2744140625,
+      "y": 757.0302734375,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 14,
+      "x": 968.2744140625,
+      "y": 755.29541015625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 15,
+      "x": 966.271484375,
+      "y": 753.67919921875,
+      "action": "fight",
+      "move_mode": "walk",
+      "type": "path"
+    }
+  ]
+}

--- a/repo/pathing/遗迹守卫/遗迹守卫13.json
+++ b/repo/pathing/遗迹守卫/遗迹守卫13.json
@@ -1,0 +1,92 @@
+{
+  "info": {
+    "name": "遗迹守卫13",
+    "type": "collect",
+    "author": "XS",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1045.5224609375,
+      "y": 950.583984375
+    },
+    {
+      "id": 2,
+      "x": 1058.1015625,
+      "y": 959.70458984375,
+      "type": "path",
+      "move_mode": "run",
+      "action": ""
+    },
+    {
+      "id": 4,
+      "x": 1088.7529296875,
+      "y": 982.99755859375,
+      "type": "path",
+      "move_mode": "fly",
+      "action": ""
+    },
+    {
+      "id": 5,
+      "x": 1094.4755859375,
+      "y": 970.66455078125,
+      "type": "path",
+      "move_mode": "run",
+      "action": ""
+    },
+    {
+      "id": 6,
+      "x": 1076.130859375,
+      "y": 975.6953125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 7,
+      "x": 1079.263671875,
+      "y": 984.4755859375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 8,
+      "x": 1110.3603515625,
+      "y": 981.8662109375,
+      "type": "target",
+      "move_mode": "run",
+      "action": ""
+    },
+    {
+      "id": 9,
+      "x": 1108.818359375,
+      "y": 1000.3193359375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 10,
+      "x": 1113.0712890625,
+      "y": 1007.28369140625,
+      "type": "path",
+      "move_mode": "fly",
+      "action": ""
+    },
+    {
+      "id": 11,
+      "x": 1117.4638671875,
+      "y": 1016.88330078125,
+      "type": "path",
+      "move_mode": "run",
+      "action": "fight"
+    }
+  ]
+}

--- a/repo/pathing/遗迹守卫/遗迹守卫14.json
+++ b/repo/pathing/遗迹守卫/遗迹守卫14.json
@@ -1,0 +1,76 @@
+{
+  "info": {
+    "name": "遗迹守卫14",
+    "type": "collect",
+    "author": "XS",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": -4217.888671875,
+      "y": -2397.8349609375
+    },
+    {
+      "id": 2,
+      "x": -4215.853515625,
+      "y": -2400.166015625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 3,
+      "x": -4221.037109375,
+      "y": -2402.3984375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 4,
+      "x": -4283.529296875,
+      "y": -2428.38671875,
+      "type": "path",
+      "move_mode": "fly",
+      "action": ""
+    },
+    {
+      "id": 6,
+      "x": -4288.61328125,
+      "y": -2431.673828125,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "stop_flying"
+    },
+    {
+      "id": 7,
+      "x": -4289.935546875,
+      "y": -2431.576171875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 7,
+      "x": -4288.802734375,
+      "y": -2432.6669921875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": ""
+    },
+    {
+      "id": 8,
+      "x": -4290.119140625,
+      "y": -2429.890625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "fight"
+    }
+  ]
+}

--- a/repo/pathing/遗迹守卫/遗迹守卫3(可回复体力).json
+++ b/repo/pathing/遗迹守卫/遗迹守卫3(可回复体力).json
@@ -1,0 +1,188 @@
+{
+  "info": {
+    "name": "遗迹守卫3(可回复体力)",
+    "type": "collect",
+    "author": "XS",
+    "version": "1.1",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 978.75,
+      "y": -353.57421875,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": 988.92578125,
+      "y": -349.26025390625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 3,
+      "x": 1002.5126953125,
+      "y": -347.17138671875,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": 1009.9033203125,
+      "y": -342.505859375,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 5,
+      "x": 1014.654296875,
+      "y": -340.251953125,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 6,
+      "x": 1101.4375,
+      "y": -321.30810546875,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "type": "path"
+    },
+    {
+      "id": 7,
+      "x": 1101.978515625,
+      "y": -303.955078125,
+      "action": "fight",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 8,
+      "x": 1115.990234375,
+      "y": -320.11962890625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 9,
+      "x": 1145.521484375,
+      "y": -342.9462890625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 10,
+      "x": 1157.8046875,
+      "y": -347.6630859375,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 11,
+      "x": 1157.69921875,
+      "y": -343.59375,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 12,
+      "x": 1158.359375,
+      "y": -346.61328125,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 13,
+      "x": 1158.8212890625,
+      "y": -348.392578125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "fight"
+    },
+    {
+      "id": 14,
+      "x": 1164.9208984375,
+      "y": -341.7900390625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 15,
+      "x": 1180.7421875,
+      "y": -318.98974609375,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 16,
+      "x": 1187.619140625,
+      "y": -294.67578125,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 17,
+      "x": 1196.111328125,
+      "y": -297.05224609375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "fight"
+    },
+    {
+      "id": 18,
+      "x": 1211.0859375,
+      "y": -280.556640625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 19,
+      "x": 1206.57421875,
+      "y": -268.76025390625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 20,
+      "x": 1193.5205078125,
+      "y": -257.5556640625,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 21,
+      "x": 1194.72265625,
+      "y": -254.2333984375,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target"
+    },
+    {
+      "id": 22,
+      "x": 1193.701171875,
+      "y": -255.1416015625,
+      "action": "fight",
+      "move_mode": "walk",
+      "type": "path"
+    }
+  ]
+}

--- a/repo/pathing/遗迹守卫/遗迹守卫4-瑶光滩.json
+++ b/repo/pathing/遗迹守卫/遗迹守卫4-瑶光滩.json
@@ -1,0 +1,76 @@
+{
+  "info": {
+    "name": "遗迹守卫4-瑶光滩",
+    "type": "collect",
+    "author": "XS",
+    "version": "1.1",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -473.98828125,
+      "y": 441.76611328125,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": -472.0205078125,
+      "y": 447.763671875,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": -492.3203125,
+      "y": 480.0810546875,
+      "action": "",
+      "move_mode": "run",
+      "type": "target"
+    },
+    {
+      "id": 4,
+      "x": -512.431640625,
+      "y": 496.78564453125,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 5,
+      "x": -525.63671875,
+      "y": 532.6513671875,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 6,
+      "x": -538.1123046875,
+      "y": 562.80712890625,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 7,
+      "x": -536.703125,
+      "y": 572.86181640625,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 8,
+      "x": -540.296875,
+      "y": 569.24267578125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "fight"
+    }
+  ]
+}


### PR DESCRIPTION
1.3.4已经修复小问题，新增13.14.
有几个点位特殊情况，需要位移小的角色，要不容易从平台掉落。
建议带 莱依拉(钟离)芙芙，万叶，芭芭拉。
