### PR TITLE
纳塔钓鱼点位

### DIFF
--- a/repo/pathing/纳塔钓鱼点位/01-烟谜主西·镜壁山.json
+++ b/repo/pathing/纳塔钓鱼点位/01-烟谜主西·镜壁山.json
@@ -1,0 +1,84 @@
+{
+  "info": {
+    "name": "烟谜主西",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 9960.999073837273,
+      "y": -1607.3959932379794,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 9999.749998252522,
+      "y": -1603.250805362095,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 10058.250117080948,
+      "y": -1581.7540268104767,
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": 10083.00012232338,
+      "y": -1576.0154169315383,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 10129.750008737385,
+      "y": -1586.7501150517282,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": 10154.500045434397,
+      "y": -1595.0029913449252,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "x": 10161.500006989907,
+      "y": -1607.25,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 8,
+      "action": "",
+      "move_mode": "run",
+      "type": "target",
+      "x": 10168.750015727292,
+      "y": -1619.248734430993,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/02-花羽会·西侧海岸.json
+++ b/repo/pathing/纳塔钓鱼点位/02-花羽会·西侧海岸.json
@@ -1,0 +1,64 @@
+{
+  "info": {
+    "name": "02-花羽会·西侧海岸",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 9839.498762786396,
+      "y": -1286.69960734318,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 9850.749294893094,
+      "y": -1255.101730788032,
+      "move_mode": "run",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 9861.999826999792,
+      "y": -1223.5038542328848,
+      "move_mode": "run",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 9897.99989515139,
+      "y": -1200.2544007285924,
+      "move_mode": "run",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 9927.750102227395,
+      "y": -1182.7527612414697,
+      "type": "path",
+      "move_mode": "run"
+    },
+    {
+      "id": 6,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target",
+      "x": 9929.625028833369,
+      "y": -1176.7496548448162,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/03-花羽会·北侧海岸.json
+++ b/repo/pathing/纳塔钓鱼点位/03-花羽会·北侧海岸.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "03-花羽会·北侧海岸",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 9547.498853655192,
+      "y": -1107.9466159982549,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "type": "target",
+      "x": 9578.75,
+      "y": -1051.1881040215712,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/04-奥奇卡纳塔·东南水域.json
+++ b/repo/pathing/纳塔钓鱼点位/04-奥奇卡纳塔·东南水域.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "04-奥奇卡纳塔·东南水域",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 9705.99797991677,
+      "y": -858.8976039621703,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "type": "path",
+      "x": 9722.625020095984,
+      "y": -889.3740220603131,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/05-奥奇卡纳塔·南侧水域.json
+++ b/repo/pathing/纳塔钓鱼点位/05-奥奇卡纳塔·南侧水域.json
@@ -1,0 +1,89 @@
+{
+  "info": {
+    "name": "05-奥奇卡纳塔·南侧水域",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 10163.498547148307,
+      "y": -402.4542094122962,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 10225.750016635706,
+      "y": -394.74562803433946,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 10259.500011090471,
+      "y": -392.4963183447071,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 10278.374990295837,
+      "y": -382.99988494827176,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 10309.250135858269,
+      "y": -400.25276124146967,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": 10314.750130313034,
+      "y": -429.75299134492525,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "x": 10316.999958410734,
+      "y": -461.99896453444853,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 8,
+      "x": 10321.374995841074,
+      "y": -489.99355710323744
+    },
+    {
+      "id": 9,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 10326.50035489507,
+      "y": -489.9139413075318,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/06-奥奇卡纳塔·北岸.json
+++ b/repo/pathing/纳塔钓鱼点位/06-奥奇卡纳塔·北岸.json
@@ -1,0 +1,54 @@
+{
+  "info": {
+    "name": "06-奥奇卡纳塔·北岸",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 10069.748970229375,
+      "y": 18.03545075398233,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 10077.250007684856,
+      "y": 18.999240978819216,
+      "move_mode": "run",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 10095.249942363585,
+      "y": 7.373705199162032,
+      "move_mode": "fly",
+      "type": "path",
+      "action": "stop_flying",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 10124.75022478202,
+      "y": -9.746517432228757,
+      "move_mode": "run"
+    },
+    {
+      "id": 5,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 10125.281244716662,
+      "y": -8.00001116207659,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/07-奥奇卡纳塔·拖佐兹之岛.json
+++ b/repo/pathing/纳塔钓鱼点位/07-奥奇卡纳塔·拖佐兹之岛.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "07-奥奇卡纳塔·拖佐兹之岛",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 9670.49689147599,
+      "y": 168.78071803367766,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "type": "target",
+      "x": 9720.000001921213,
+      "y": 156.24928562712375,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/纳塔钓鱼点位/08-奥奇卡纳塔·东侧水域.json
+++ b/repo/pathing/纳塔钓鱼点位/08-奥奇卡纳塔·东侧水域.json
@@ -1,0 +1,55 @@
+{
+  "info": {
+    "name": "08-奥奇卡纳塔·东侧水域",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 9433.499492799543,
+      "y": -352.8440881197648,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 9412.750026896994,
+      "y": -357.25026788982814,
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 9322.125001921213,
+      "y": -351.50214311862874,
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 9247.999980787861,
+      "y": -344.2504464830472,
+      "move_mode": "fly",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "action": "",
+      "move_mode": "fly",
+      "type": "target",
+      "x": 9189.562477906042,
+      "y": -332.56274556567587,
+      "action_params": ""
+    }
+  ]
+}


### PR DESCRIPTION
5.3版本纳塔点位全11-3个，三个地下锚点暂时无法提供寻路