### PR TITLE
璃月钓鱼点位

### DIFF
--- a/repo/pathing/璃月钓鱼点位/01-轻策庄.json
+++ b/repo/pathing/璃月钓鱼点位/01-轻策庄.json
@@ -1,0 +1,62 @@
+{
+  "info": {
+    "name": "01-轻策庄",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 545.5018873146691,
+      "y": 1764.999999910242,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 543.2520760461357,
+      "y": 1760.999999977561,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 532.3756605601338,
+      "y": 1767.749999887803
+    },
+    {
+      "id": 4,
+      "x": 519.7484901482658,
+      "y": 1772.0000010546519,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 494.4954704447955,
+      "y": 1784.0000017502734,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "action": "",
+      "move_mode": "fly",
+      "type": "path",
+      "x": 457.24853733113196,
+      "y": 1814.3437501234166,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/02-璃月港.json
+++ b/repo/pathing/璃月钓鱼点位/02-璃月港.json
@@ -1,0 +1,177 @@
+{
+  "info": {
+    "name": "02-璃月港",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 269.89808500789695,
+      "y": -666.9999731624848,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": 212.99698029652973,
+      "y": -662.0000015258793,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": 187.24830141679922,
+      "y": -680.4999997756058,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": 165.99660283359663,
+      "y": -688.5000002917122,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 5,
+      "x": 154.06273591433273,
+      "y": -704.9382181728597,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 6,
+      "x": 120.75,
+      "y": -705.2506047771449,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 7,
+      "x": 111.75113238880112,
+      "y": -711.4999994726741,
+      "action": "",
+      "move_mode": "fly",
+      "type": "path"
+    },
+    {
+      "id": 8,
+      "x": 97.375,
+      "y": -712.1252267914297,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 9,
+      "x": 88.1229239538643,
+      "y": -712.7499999719512,
+      "type": "path",
+      "move_mode": "walk"
+    },
+    {
+      "id": 10,
+      "x": 84.375,
+      "y": -712.7503779857161,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 11,
+      "x": 35.87273522239775,
+      "y": -728.0005291800016,
+      "action": "",
+      "move_mode": "fly",
+      "type": "path"
+    },
+    {
+      "id": 12,
+      "x": 30.000471828667287,
+      "y": -727.8753023885729,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 13,
+      "x": 26.000047182868002,
+      "y": -750.0625,
+      "move_mode": "swim",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 14,
+      "x": 24.62518873146655,
+      "y": -765.7499996746292,
+      "move_mode": "swim",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 15,
+      "x": 22.625471828667287,
+      "y": -774.2499998204848,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path"
+    },
+    {
+      "id": 16,
+      "x": -10.374716902799264,
+      "y": -761.625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 17,
+      "x": -44.2483014167974,
+      "y": -748.9989416399958,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 18,
+      "x": -63.124056342665426,
+      "y": -755.7499244028568,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 19,
+      "x": -81.99981126853345,
+      "y": -762.5009071657178,
+      "action": "",
+      "move_mode": "run",
+      "type": "path"
+    },
+    {
+      "id": 20,
+      "x": -100.12150846786244,
+      "y": -745.8125000617083,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/03-荻花洲.json
+++ b/repo/pathing/璃月钓鱼点位/03-荻花洲.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "name": "03-荻花洲",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "可能会奖励一个突发事件",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 483.4988676111989,
+      "y": 1443,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 483.0,
+      "y": 1429.0,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 485.50264224053535,
+      "y": 1391.5006047771458,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 475.0147210544146,
+      "y": 1347.4791351884942,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 424.18764154860037,
+      "y": 1315.312386604286,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/04-碧水原.json
+++ b/repo/pathing/璃月钓鱼点位/04-碧水原.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "04-碧水原",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1271.9494199668825,
+      "y": 1560.4265195768712,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1210.500377462933,
+      "y": 1548.4987904457103,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "action": "",
+      "move_mode": "run",
+      "type": "path",
+      "x": 1145.8119809884665,
+      "y": 1536.8741684314264,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/05-碧水原2.json
+++ b/repo/pathing/璃月钓鱼点位/05-碧水原2.json
@@ -1,0 +1,75 @@
+{
+  "info": {
+    "name": "05-碧水原2",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "钓鱼点附近有丘丘人打手",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1114.8222149582216,
+      "y": 1190.386906673868,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1096.9932056671933,
+      "y": 1211.5027214971524,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 1097.0075492586748,
+      "y": 1227.9978832799916,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 1060.500754925868,
+      "y": 1261.4933474514037,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 1038.5052844810725,
+      "y": 1311.5018143314355,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": 1014.5016985832026,
+      "y": 1328.2498488057136,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 1004.5015098517342,
+      "y": 1356.7504535828593,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/06-奥藏山.json
+++ b/repo/pathing/璃月钓鱼点位/06-奥藏山.json
@@ -1,0 +1,84 @@
+{
+  "info": {
+    "name": "06-奥藏山",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1605.319025478646,
+      "y": 1041.8586524917137,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1594.4381133772677,
+      "y": 1038.24901723714,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 1569.3735845139981,
+      "y": 1036.4962957399857,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 1547.971312817037,
+      "y": 1046.9925914799733,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 1554.7549070181376,
+      "y": 1079.1231100714213,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": 1576.50358589787,
+      "y": 1097.9934986456901,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "x": 1576.627170411868,
+      "y": 1120.8750755971432,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 8,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target",
+      "x": 1578.3761323888011,
+      "y": 1140.6248488057136,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/07-琥牢山.json
+++ b/repo/pathing/璃月钓鱼点位/07-琥牢山.json
@@ -1,0 +1,71 @@
+{
+  "info": {
+    "name": "07-琥牢山",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "需要开启周本“伏龙树之底”",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1753.8462184513046,
+      "y": 607.5810024626944,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1763.1243394398662,
+      "y": 586.7504535828584,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 1746.5033971664034,
+      "y": 557.870086185696,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 1697.9903746951895,
+      "y": 582.7489416399958
+    },
+    {
+      "id": 5,
+      "x": 1657.4803719274478,
+      "y": 626.7543846343015,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": 1639.4950929818624,
+      "y": 664.9996976114271,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 1641.000377462933,
+      "y": 688.375,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/08-天遒谷.json
+++ b/repo/pathing/璃月钓鱼点位/08-天遒谷.json
@@ -1,0 +1,71 @@
+{
+  "info": {
+    "name": "08-天遒谷",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "右后方可能会有一只<大伟丘>",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1153.735398483468,
+      "y": 139.92772913116187,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1152.9807493903809,
+      "y": 127.50393105144303,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 1203.5056619440056,
+      "y": 102.4764136913418,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 1285.0052844810725,
+      "y": 133.49092834282328,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 1306.5033971664034,
+      "y": 143.99909283428224,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 1322.5005661944015,
+      "y": 144.49939522285513,
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "x": 1322.7501887314666,
+      "y": 144.37492440285678
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/09-珉林.json
+++ b/repo/pathing/璃月钓鱼点位/09-珉林.json
@@ -1,0 +1,93 @@
+{
+  "info": {
+    "name": "09-珉林",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 725.4882986490557,
+      "y": 1062.5435439544472,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 713.7481126853327,
+      "y": 1049.2204603544087,
+      "move_mode": "fly",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": 702.0079267216097,
+      "y": 1035.8973767543685,
+      "move_mode": "walk",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": 678.5275547941619,
+      "y": 1009.2512095542897,
+      "move_mode": "run",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 5,
+      "x": 635.276422405359,
+      "y": 977.4987904457103,
+      "move_mode": "run",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 6,
+      "x": 591.5018873146691,
+      "y": 929.2495464171416,
+      "move_mode": "run",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 7,
+      "x": 570.3769816804015,
+      "y": 927.5001511942864,
+      "move_mode": "walk",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 8,
+      "x": 559.7502830972007,
+      "y": 940.2500755971432,
+      "move_mode": "walk",
+      "action": "",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 9,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target",
+      "x": 556.3128302800669,
+      "y": 951.6865928342822,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/10-归离原.json
+++ b/repo/pathing/璃月钓鱼点位/10-归离原.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "10-归离原",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": -53.75136969045525,
+      "y": 659.4534321598276,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "action": "",
+      "move_mode": "run",
+      "type": "path",
+      "x": -11.74999575289803,
+      "y": 643.3741619472685,
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 20,
+      "y": 646.4998323894533,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target",
+      "x": 52.500006370653864,
+      "y": 648.9999441298178,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/11-渌华池.json
+++ b/repo/pathing/璃月钓鱼点位/11-渌华池.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "11-渌华池",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "需完成解谜“渌华池之影”并开启副本风场",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 523.9995349423116,
+      "y": 101.65617556161942,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 527.0000148648578,
+      "y": 106.75223480728437,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "combat_script",
+      "action_params": "wait(2),keydown(Space),wait(0.1),keyup(Space),wait(0.2),keydown(Space),wait(0.1),keyup(Space),wait(5)"
+    },
+    {
+      "id": 3,
+      "action": "stop_flying",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 529.5000254826136,
+      "y": 128.49698301016542,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/12-沉玉谷上谷·东侧水域.json
+++ b/repo/pathing/璃月钓鱼点位/12-沉玉谷上谷·东侧水域.json
@@ -1,0 +1,66 @@
+{
+  "info": {
+    "name": "12-沉玉谷上谷·东侧水域",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1107.9990698846213,
+      "y": 1945.0273763892365,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1127.6249522200997,
+      "y": 1952.2522348072853,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 1135.7500106177558,
+      "y": 1921.7510056632782,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 1130.1250095559808,
+      "y": 1893.625502831639,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 1123.0000191119598,
+      "y": 1861.6249441298187,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "action": "",
+      "move_mode": "walk",
+      "type": "path",
+      "x": 1106.8749224903859,
+      "y": 1865.4997206490898,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/13-古茶树坡·北侧水域.json
+++ b/repo/pathing/璃月钓鱼点位/13-古茶树坡·北侧水域.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "name": "13-古茶树坡·北侧水域",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 1690.749004054538,
+      "y": 1831.546372251154,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 1695.9999893822442,
+      "y": 1835.8761174036426,
+      "move_mode": "walk",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 1703.8741155409698,
+      "y": 1845.1652824013036,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 1713.9999745173864,
+      "y": 1866.4965360487095,
+      "move_mode": "fly",
+      "type": "path",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "type": "target",
+      "x": 1724.5,
+      "y": 1890,
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/璃月钓鱼点位/14-悬练山·西南水域.json
+++ b/repo/pathing/璃月钓鱼点位/14-悬练山·西南水域.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "14-悬练山·西南水域",
+    "type": "collect",
+    "author": "鸿羽er",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 2255.488507207301,
+      "y": 923.9617132754038,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 2275.4971690279963,
+      "y": 932.2499987433939,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 2294.0028309720037,
+      "y": 913.2500006956216,
+      "type": "path",
+      "move_mode": "run",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "action": "",
+      "move_mode": "walk",
+      "type": "target",
+      "x": 2304.772459044556,
+      "y": 909.7499984068027,
+      "action_params": ""
+    }
+  ]
+}


### PR DESCRIPTION
璃月钓鱼点位全11+沉玉谷3共14个点位，不包含层岩巨渊地图的两个点位