### PR TITLE
路径追踪：骗骗花、飘浮灵、垂钓点

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,5 @@
 {
-  "time": "20250217193101",
+  "time": "20250217212146",
   "url": "https://github.com/babalae/bettergi-scripts-list/archive/refs/heads/main.zip",
   "file": "repo.json",
   "indexes": [

--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,5 @@
 {
-  "time": "20250217212146",
+  "time": "20250217212230",
   "url": "https://github.com/babalae/bettergi-scripts-list/archive/refs/heads/main.zip",
   "file": "repo.json",
   "indexes": [
@@ -18815,8 +18815,8 @@
             {
               "name": "璃月-骗骗花-云来海孤云阁东方崖上和南方岸边-2个.json",
               "type": "file",
-              "hash": "58954dc27f5f7b67021430d803367bfabafd2dbd",
-              "version": "58954dc",
+              "hash": "30da3b4dedcefaddd7b6bd21801f5b7837e882e1",
+              "version": "30da3b4",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n璃月-云来海孤云阁东方崖上和南方岸边",
               "tags": [
@@ -18848,8 +18848,8 @@
             {
               "name": "璃月-骗骗花-层岩巨渊巨渊之口东南-6个.json",
               "type": "file",
-              "hash": "39b3ba7969a8a6d470143193944af2e1d61fdccd",
-              "version": "39b3ba7",
+              "hash": "dd081f55cb108350c7a8674f8d7c9356dd77380a",
+              "version": "dd081f5",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-6个\n璃月-层岩巨渊巨渊之口东南",
               "tags": [
@@ -18914,8 +18914,8 @@
             {
               "name": "璃月-骗骗花-珉林奥藏山南方-1个.json",
               "type": "file",
-              "hash": "b0baf53ac8de54e16fe75263c415788ecaa05547",
-              "version": "b0baf53",
+              "hash": "3c9a0ad37348393cec73f1b6f0d0f27d8817fdde",
+              "version": "3c9a0ad",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林奥藏山南方",
               "tags": [
@@ -18925,8 +18925,8 @@
             {
               "name": "璃月-骗骗花-珉林奥藏山西南方-1个.json",
               "type": "file",
-              "hash": "7ebcb0fbee39a5108ce540812956f4e502a19420",
-              "version": "7ebcb0f",
+              "hash": "8325c2491deb02a60850e31d3ec241e238636c43",
+              "version": "8325c24",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林奥藏山西南方",
               "tags": [
@@ -19200,8 +19200,8 @@
             {
               "name": "稻妻-骗骗花-八酝岛蛇神之首西南-3个.json",
               "type": "file",
-              "hash": "6787c8d847a603942e1c557b0d51037f14e728c9",
-              "version": "6787c8d",
+              "hash": "0a167ae316ffbc325306727ca19ea7225b9f90bb",
+              "version": "0a167ae",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n稻妻-八酝岛蛇神之首西南",
               "tags": [
@@ -19244,8 +19244,8 @@
             {
               "name": "稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个.json",
               "type": "file",
-              "hash": "6022a1f69d7ab4f05385c4744ac225feedad4fc5",
-              "version": "6022a1f",
+              "hash": "e3a4898a453f9ac15b5f4259d735ed8db9c5f79e",
+              "version": "e3a4898",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-5个\n稻妻-海祇岛珊瑚宫北方略偏西",
               "tags": [

--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,5 @@
 {
-  "time": "20250217212230",
+  "time": "20250217212543",
   "url": "https://github.com/babalae/bettergi-scripts-list/archive/refs/heads/main.zip",
   "file": "repo.json",
   "indexes": [
@@ -19798,12 +19798,298 @@
               ]
             },
             {
+              "name": "稻妻-飘浮灵-海祇岛曚云神社东北-3个.json",
+              "type": "file",
+              "hash": "3e904e32beccac07b59b37935e0440e180634433",
+              "version": "3e904e3",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n稻妻-海祇岛曚云神社东北",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛曚云神社东南-4个.json",
+              "type": "file",
+              "hash": "a8627cedf60b009c202cd952bf43e7a61e410a9f",
+              "version": "a8627ce",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-海祇岛曚云神社东南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛曚云神社西南-3个.json",
+              "type": "file",
+              "hash": "58ca4e344e673f87720c658073c2ad329c373b6f",
+              "version": "58ca4e3",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n稻妻-海祇岛曚云神社西南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛望泷村东-4个.json",
+              "type": "file",
+              "hash": "b49d4bc35aa81c465b7d48068c16b22b19f403ee",
+              "version": "b49d4bc",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-海祇岛望泷村东",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛望泷村南-2个.json",
+              "type": "file",
+              "hash": "0403406a5a4af6549122ee4f444a4eb4fb745a82",
+              "version": "0403406",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-2个\n稻妻-海祇岛望泷村南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛望泷村西南-2个.json",
+              "type": "file",
+              "hash": "0bfba0ce87984cdc0c9256b641a885dad6046ef2",
+              "version": "0bfba0c",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-2个\n稻妻-海祇岛望泷村西南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛水月池东南-2个.json",
+              "type": "file",
+              "hash": "7786d3ac460c581e660e67c144929ff824625904",
+              "version": "7786d3a",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-2个\n稻妻-海祇岛水月池东南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛水月池南-8个.json",
+              "type": "file",
+              "hash": "845ceb6571b02e1776c0beb2c6cfa09db011932c",
+              "version": "845ceb6",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-8个\n稻妻-海祇岛水月池南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛珊瑚宫下东北-2个.json",
+              "type": "file",
+              "hash": "2487f4f06375595c805515f2180c053e7a0a7cd6",
+              "version": "2487f4f",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-2个\n稻妻-海祇岛珊瑚宫下东北",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛珊瑚宫东北岸边-3个.json",
+              "type": "file",
+              "hash": "5c19009763ea9e59a770b11c0855776a41fc4d08",
+              "version": "5c19009",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n稻妻-海祇岛珊瑚宫东北岸边",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛珊瑚宫东北崖下-4个.json",
+              "type": "file",
+              "hash": "25f864ea8389484d75aaddffaf3048eb35052efa",
+              "version": "25f864e",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-海祇岛珊瑚宫东北崖下",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-海祇岛珊瑚宫北-4个.json",
+              "type": "file",
+              "hash": "bd1eac02e8778b77e136d80b85b659b27c8c789f",
+              "version": "bd1eac0",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-海祇岛珊瑚宫北",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛天云峠东-6个.json",
+              "type": "file",
+              "hash": "b5a4908ee6c11ad1347c22738df1f9aba78bc5bb",
+              "version": "b5a4908",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-6个\n稻妻-清籁岛天云峠东",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛天云峠东南山边-11个.json",
+              "type": "file",
+              "hash": "ebb6f53fa51455e5b6ed7d054368e72711a4df32",
+              "version": "ebb6f53",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-11个\n稻妻-清籁岛天云峠东南山边",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛天云峠东南岸边-7个.json",
+              "type": "file",
+              "hash": "566bae458982126590b248397e8146d68ed280ba",
+              "version": "566bae4",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-7个\n稻妻-清籁岛天云峠东南岸边",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛天云峠南-4个.json",
+              "type": "file",
+              "hash": "dfa00f6ed5b31e516382140cfc44cfd166730482",
+              "version": "dfa00f6",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-清籁岛天云峠南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛天云峠西-21个.json",
+              "type": "file",
+              "hash": "6ed10c5853fbbe597a7c8025fb1dd565c796261a",
+              "version": "6ed10c5",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-21个\n稻妻-清籁岛天云峠西",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛平海砦-5个.json",
+              "type": "file",
+              "hash": "3fd462de215807e226079d0d547d6a765b152ed6",
+              "version": "3fd462d",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-5个\n稻妻-清籁岛平海砦",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛平海砦西北岸边-4个.json",
+              "type": "file",
+              "hash": "68e46df2e3112c277954e0db04abf11c62ef3540",
+              "version": "68e46df",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-清籁岛平海砦西北岸边",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛平海砦西崖下-4个.json",
+              "type": "file",
+              "hash": "9efe2b379cd1bbc33fe81f605f34905507a283ed",
+              "version": "9efe2b3",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-4个\n稻妻-清籁岛平海砦西崖下",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛浅濑神社北-3个.json",
+              "type": "file",
+              "hash": "51869f5dcb619f1dd35e75073265ff472ec634b8",
+              "version": "51869f5",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n稻妻-清籁岛浅濑神社北",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛越石村南-2个.json",
+              "type": "file",
+              "hash": "d9de64becf0417f1eec608929b7a44b26674ba9e",
+              "version": "d9de64b",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-2个\n稻妻-清籁岛越石村南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-清籁岛越石村西北-3个.json",
+              "type": "file",
+              "hash": "b0599aa2231184ba47c0277f3cc07ef0bd94a8a3",
+              "version": "b0599aa",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n稻妻-清籁岛越石村西北",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "稻妻-飘浮灵-鹤观惑饲滩西南-3个.json",
+              "type": "file",
+              "hash": "3d5369bf49fe382dfdcad037201bb38396bc8445",
+              "version": "3d5369b",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n稻妻-鹤观惑饲滩西南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
               "name": "越石村3只 .json",
               "type": "file",
               "hash": "e640a5ef39b784cdfed0d52e47d701b72ec918f6",
               "version": "e640a5e",
               "author": "baixi",
               "description": "",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "须弥-飘浮灵-二净甸桓那兰那西南-3个.json",
+              "type": "file",
+              "hash": "0ce9d0aed9ca5efca0057eb18911a450f1a99e1d",
+              "version": "0ce9d0a",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-3个\n须弥-二净甸桓那兰那西南",
+              "tags": [
+                "飘浮灵"
+              ]
+            },
+            {
+              "name": "须弥-飘浮灵-二净甸觉王之殿东-6个.json",
+              "type": "file",
+              "hash": "e4c5ef5865e39a613b673f08104b2adb9a9b5a19",
+              "version": "e4c5ef5",
+              "author": "提瓦特钓鱼玳师",
+              "description": "飘浮灵-6个\n须弥-二净甸觉王之殿东",
               "tags": [
                 "飘浮灵"
               ]

--- a/repo/pathing/垂钓点/枫丹-垂钓点-伊黎耶林区幽林雾道西南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-伊黎耶林区幽林雾道西南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-伊黎耶林区幽林雾道西南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、波波心羽鲈、烘烘心羽鲈、维护机关·水域清理者、维护机关·态势控制者、维护机关·澄金领队型\n所需鱼饵: 果酿饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n维护机关·澄金领队型(维护机关频闪诱饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3367.25,
+            "y": 3294.29,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3402.91,
+            "y": 3277.5,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 3409.29,
+            "y": 3239.73,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3399.85,
+            "y": 3200.1,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 3413.07,
+            "y": 3165.09,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 3416.3,
+            "y": 3162.42,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 3414.57,
+            "y": 3159.98,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-伊黎耶林区柔灯港西北-海涛斧枪鱼_波波心羽鲈_维护机关·水域清理者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-伊黎耶林区柔灯港西北-海涛斧枪鱼_波波心羽鲈_维护机关·水域清理者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-伊黎耶林区柔灯港西北-海涛斧枪鱼_波波心羽鲈_维护机关·水域清理者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、波波心羽鲈、维护机关·水域清理者、维护机关·澄金领队型\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·澄金领队型(维护机关频闪诱饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2889.82,
+            "y": 3186.38,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2893.67,
+            "y": 3204.7,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2885.13,
+            "y": 3248.58,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 2895.09,
+            "y": 3256.25,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-枫丹动能工程科学研究院区中央实验室遗址南-花鳉_海涛斧枪鱼_波波心羽鲈_维护机关·初始能力型_维护机关·水域清理者-果酿饵_甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-枫丹动能工程科学研究院区中央实验室遗址南-花鳉_海涛斧枪鱼_波波心羽鲈_维护机关·初始能力型_维护机关·水域清理者-果酿饵_甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-枫丹动能工程科学研究院区中央实验室遗址南-花鳉_海涛斧枪鱼_波波心羽鲈_维护机关·初始能力型_维护机关·水域清理者-果酿饵_甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、海涛斧枪鱼、波波心羽鲈、维护机关·初始能力型、维护机关·水域清理者\n所需鱼饵: 果酿饵、甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n海涛斧枪鱼(甘露饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n维护机关·初始能力型(维护机关频闪诱饵)[全天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 3865.14,
+            "y": 4492.28,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3976.28,
+            "y": 4527.77,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(2.3),attack(0.1)"
+        },
+        {
+            "id": 3,
+            "x": 3982.21,
+            "y": 4532.11,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3984.27,
+            "y": 4531.78,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-枫丹听取茉洁站西南-海涛斧枪鱼_烘烘心羽鲈_维护机关·初始能力型_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-枫丹听取茉洁站西南-海涛斧枪鱼_烘烘心羽鲈_维护机关·初始能力型_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-枫丹听取茉洁站西南-海涛斧枪鱼_烘烘心羽鲈_维护机关·初始能力型_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、烘烘心羽鲈、维护机关·初始能力型、维护机关·态势控制者\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·初始能力型(维护机关频闪诱饵)[全天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3774.01,
+            "y": 3783.97,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3789.33,
+            "y": 3763.73,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f),wait(10)"
+        },
+        {
+            "id": 3,
+            "x": 3898.53,
+            "y": 3533.49,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3913.76,
+            "y": 3539.38,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-枫丹廷区枫丹廷南-花鳉_海涛斧枪鱼_维护机关·水域清理者_维护机关·态势控制者-果酿饵_甘露饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-枫丹廷区枫丹廷南-花鳉_海涛斧枪鱼_维护机关·水域清理者_维护机关·态势控制者-果酿饵_甘露饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,228 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-枫丹廷区枫丹廷南-花鳉_海涛斧枪鱼_维护机关·水域清理者_维护机关·态势控制者-果酿饵_甘露饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、海涛斧枪鱼、维护机关·水域清理者、维护机关·态势控制者\n所需鱼饵: 果酿饵、甘露饵、维护机关频闪诱饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n海涛斧枪鱼(甘露饵)[全天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 4610.5,
+            "y": 3600.66,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 2,
+            "x": 4642.21,
+            "y": 3593.04,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": 4657.85,
+            "y": 3605.44,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 4,
+            "x": 4665.74,
+            "y": 3613.75,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 5,
+            "x": 4708.21,
+            "y": 3622.92,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 6,
+            "x": 4719.72,
+            "y": 3611.18,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        },
+        {
+            "id": 7,
+            "x": 4718.69,
+            "y": 3603.65,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        },
+        {
+            "id": 8,
+            "x": 4709.38,
+            "y": 3598.02,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        },
+        {
+            "id": 9,
+            "x": 4709.4,
+            "y": 3576.47,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 10,
+            "x": 4708,
+            "y": 3564.49,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        },
+        {
+            "id": 11,
+            "x": 4690.07,
+            "y": 3550.97,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 12,
+            "x": 4681.96,
+            "y": 3543.32,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "target"
+        },
+        {
+            "id": 13,
+            "x": 4682.05,
+            "y": 3540.0,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 14,
+            "x": 4676.26,
+            "y": 3471.04,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 15,
+            "x": 4658.33,
+            "y": 3439.87,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 16,
+            "x": 4646.13,
+            "y": 3426.82,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 17,
+            "x": 4638.15,
+            "y": 3411.75,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 18,
+            "x": 4610.15,
+            "y": 3393.97,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 19,
+            "x": 4585.22,
+            "y": 3385.43,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 20,
+            "x": 4506.69,
+            "y": 3276.62,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 21,
+            "x": 4502.51,
+            "y": 3267.08,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 22,
+            "x": 4490.26,
+            "y": 3245.68,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 23,
+            "x": 4466.58,
+            "y": 3238.96,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 24,
+            "x": 4467.24,
+            "y": 3235.98,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-白露区白淞镇西南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·白金典藏型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-白露区白淞镇西南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·白金典藏型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-白露区白淞镇西南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·白金典藏型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、波波心羽鲈、烘烘心羽鲈、维护机关·水域清理者、维护机关·白金典藏型\n所需鱼饵: 果酿饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·白金典藏型(维护机关频闪诱饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4147.55,
+            "y": 2607.45,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4190.81,
+            "y": 2621.49,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4337.25,
+            "y": 2651.36,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4339.33,
+            "y": 2651.38,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-翡黎区芒索斯山东麓东-海涛斧枪鱼_烘烘心羽鲈_维护机关·初始能力型_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-翡黎区芒索斯山东麓东-海涛斧枪鱼_烘烘心羽鲈_维护机关·初始能力型_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-翡黎区芒索斯山东麓东-海涛斧枪鱼_烘烘心羽鲈_维护机关·初始能力型_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、烘烘心羽鲈、维护机关·初始能力型、维护机关·态势控制者\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·初始能力型(维护机关频闪诱饵)[全天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4984.74,
+            "y": 4462.95,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4929.13,
+            "y": 4445.92,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4894.21,
+            "y": 4408.47,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4874.83,
+            "y": 4394.5,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 4871.91,
+            "y": 4390.95,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 4868.41,
+            "y": 4395.03,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-苍晶区厄里那斯东-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·初始能力型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-苍晶区厄里那斯东-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·初始能力型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-苍晶区厄里那斯东-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·初始能力型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、波波心羽鲈、烘烘心羽鲈、维护机关·初始能力型\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·初始能力型(维护机关频闪诱饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4751.99,
+            "y": 2643.99,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4737.37,
+            "y": 2676.7,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4658.31,
+            "y": 2709.61,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4635.26,
+            "y": 2745.61,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 4625.03,
+            "y": 2740.98,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-苍晶区厄里那斯东北-吹沙角鲀_波波心羽鲈_维护机关·初始能力型_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-苍晶区厄里那斯东北-吹沙角鲀_波波心羽鲈_维护机关·初始能力型_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-苍晶区厄里那斯东北-吹沙角鲀_波波心羽鲈_维护机关·初始能力型_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 吹沙角鲀、波波心羽鲈、维护机关·初始能力型、维护机关·水域清理者、维护机关·态势控制者\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n吹沙角鲀(甘露饵)[白天]\n波波心羽鲈(酸桔饵)[夜晚]\n维护机关·初始能力型(维护机关频闪诱饵)[全天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4705.51,
+            "y": 2951.55,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4715.22,
+            "y": 2973.37,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4741.52,
+            "y": 3005.44,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4744.16,
+            "y": 3007.0,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 4741.07,
+            "y": 3011.2,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-苍晶区海露港北-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-苍晶区海露港北-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-苍晶区海露港北-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、波波心羽鲈、烘烘心羽鲈、维护机关·水域清理者、维护机关·态势控制者\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4876.57,
+            "y": 2255.2,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4889.67,
+            "y": 2236.93,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4949.4,
+            "y": 2214.19,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4945.7,
+            "y": 2210.51,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-莫尔泰区卡布狄斯堡遗迹南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·态势控制者_维护机关·澄金领队型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-莫尔泰区卡布狄斯堡遗迹南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·态势控制者_维护机关·澄金领队型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-莫尔泰区卡布狄斯堡遗迹南-花鳉_波波心羽鲈_烘烘心羽鲈_维护机关·态势控制者_维护机关·澄金领队型-果酿饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、波波心羽鲈、烘烘心羽鲈、维护机关·态势控制者、维护机关·澄金领队型\n所需鱼饵: 果酿饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n维护机关·澄金领队型(维护机关频闪诱饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3463.27,
+            "y": 2286.31,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3467.56,
+            "y": 2300.31,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 3421.63,
+            "y": 2359.2,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3424.7,
+            "y": 2363.21,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-莫尔泰区欧庇克莱歌剧院南-海涛斧枪鱼_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-莫尔泰区欧庇克莱歌剧院南-海涛斧枪鱼_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-莫尔泰区欧庇克莱歌剧院南-海涛斧枪鱼_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、烘烘心羽鲈、维护机关·水域清理者、维护机关·态势控制者、维护机关·澄金领队型\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n维护机关·澄金领队型(维护机关频闪诱饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3955.48,
+            "y": 2869.18,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3954.76,
+            "y": 2881.53,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 3945.67,
+            "y": 2914.06,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3834.11,
+            "y": 2977.14,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 3822.74,
+            "y": 2958.43,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/枫丹-垂钓点-诺思托伊区佩特莉可镇南-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·初始能力型_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
+++ b/repo/pathing/垂钓点/枫丹-垂钓点-诺思托伊区佩特莉可镇南-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·初始能力型_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "枫丹-垂钓点-诺思托伊区佩特莉可镇南-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·初始能力型_维护机关·水域清理者_维护机关·态势控制者_维护机关·澄金领队型-甘露饵_酸桔饵_维护机关频闪诱饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 海涛斧枪鱼、波波心羽鲈、烘烘心羽鲈、维护机关·初始能力型、维护机关·水域清理者、维护机关·态势控制者、维护机关·澄金领队型\n所需鱼饵: 甘露饵、酸桔饵、维护机关频闪诱饵\n鱼类详情: \n海涛斧枪鱼(甘露饵)[全天]\n波波心羽鲈(酸桔饵)[夜晚]\n烘烘心羽鲈(酸桔饵)[白天]\n维护机关·初始能力型(维护机关频闪诱饵)[全天]\n维护机关·水域清理者(维护机关频闪诱饵)[白天]\n维护机关·态势控制者(维护机关频闪诱饵)[夜晚]\n维护机关·澄金领队型(维护机关频闪诱饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4322.26,
+            "y": 1172.83,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4339.27,
+            "y": 1168.1,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4356.35,
+            "y": 1105.41,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4349.37,
+            "y": 1094.5,
+            "type": "target",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 4359.29,
+            "y": 1084.75,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 4356.22,
+            "y": 1083.51,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 4359.29,
+            "y": 1079.09,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-云来海璃月港东南-甜甜花鳉_擒霞客_水晶宴_斗棘鱼_炮鲀-果酿饵_赤糜饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-云来海璃月港东南-甜甜花鳉_擒霞客_水晶宴_斗棘鱼_炮鲀-果酿饵_赤糜饵_飞蝇假饵-普通.json
@@ -1,0 +1,183 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-云来海璃月港东南-甜甜花鳉_擒霞客_水晶宴_斗棘鱼_炮鲀-果酿饵_赤糜饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 甜甜花鳉、擒霞客、水晶宴、斗棘鱼、炮鲀\n所需鱼饵: 果酿饵、赤糜饵、飞蝇假饵\n鱼类详情: \n甜甜花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n斗棘鱼(赤糜饵)[夜晚]\n炮鲀(飞蝇假饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 267.52,
+            "y": -665.19,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 263.87,
+            "y": -662.59,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 250.9,
+            "y": -664.93,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 212.72,
+            "y": -662.63,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 189.12,
+            "y": -681.85,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 163.53,
+            "y": -683.5,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 151.61,
+            "y": -703.26,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": 120.28,
+            "y": -705.06,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": 94.39,
+            "y": -711.99,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 10,
+            "x": 31.46,
+            "y": -712.44,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 11,
+            "x": 31.19,
+            "y": -718.66,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 12,
+            "x": 16.14,
+            "y": -719.52,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 13,
+            "x": 14.48,
+            "y": -727.0,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 14,
+            "x": 3.13,
+            "y": -734.03,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 15,
+            "x": -18.14,
+            "y": -747.23,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 16,
+            "x": -72.74,
+            "y": -756.07,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 17,
+            "x": -97.43,
+            "y": -756.52,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 18,
+            "x": -102.21,
+            "y": -752.38,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 19,
+            "x": -99.23,
+            "y": -747.2,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-沉玉谷·上谷古树茶坡-花鳉_斗棘鱼_流纹褐蝶鱼_锖假龙_金赤假龙_玉玉心羽鲈-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵_酸桔饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-沉玉谷·上谷古树茶坡-花鳉_斗棘鱼_流纹褐蝶鱼_锖假龙_金赤假龙_玉玉心羽鲈-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵_酸桔饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-沉玉谷·上谷古树茶坡-花鳉_斗棘鱼_流纹褐蝶鱼_锖假龙_金赤假龙_玉玉心羽鲈-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵_酸桔饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、斗棘鱼、流纹褐蝶鱼、锖假龙、金赤假龙、玉玉心羽鲈\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵、酸桔饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n斗棘鱼(赤糜饵)[夜晚]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n锖假龙(飞蝇假饵)[全天]\n金赤假龙(飞蝇假饵)[全天]\n玉玉心羽鲈(酸桔饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 1692.1,
+            "y": 1829.41,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1695.38,
+            "y": 1833.56,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 1721.02,
+            "y": 1892.65,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(1.5),attack(0.1)"
+        },
+        {
+            "id": 4,
+            "x": 1721.84,
+            "y": 1894.41,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-沉玉谷·上谷古树茶坡东-花鳉_擒霞客_水晶宴_斗棘鱼_锖假龙_玉玉心羽鲈-果酿饵_赤糜饵_飞蝇假饵_酸桔饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-沉玉谷·上谷古树茶坡东-花鳉_擒霞客_水晶宴_斗棘鱼_锖假龙_玉玉心羽鲈-果酿饵_赤糜饵_飞蝇假饵_酸桔饵-普通.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-沉玉谷·上谷古树茶坡东-花鳉_擒霞客_水晶宴_斗棘鱼_锖假龙_玉玉心羽鲈-果酿饵_赤糜饵_飞蝇假饵_酸桔饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、擒霞客、水晶宴、斗棘鱼、锖假龙、玉玉心羽鲈\n所需鱼饵: 果酿饵、赤糜饵、飞蝇假饵、酸桔饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n斗棘鱼(赤糜饵)[夜晚]\n锖假龙(飞蝇假饵)[全天]\n玉玉心羽鲈(酸桔饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 1114.88,
+            "y": 1948.03,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1134.28,
+            "y": 1930.28,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 1132.97,
+            "y": 1890.3,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 1124.21,
+            "y": 1870.08,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 1107.88,
+            "y": 1861.32,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 1105.25,
+            "y": 1865.1,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-沉玉谷·南陵悬练山西南-甜甜花鳉_擒霞客_赤魔王_金赤假龙_玉玉心羽鲈-果酿饵_赤糜饵_飞蝇假饵_酸桔饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-沉玉谷·南陵悬练山西南-甜甜花鳉_擒霞客_赤魔王_金赤假龙_玉玉心羽鲈-果酿饵_赤糜饵_飞蝇假饵_酸桔饵-普通.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-沉玉谷·南陵悬练山西南-甜甜花鳉_擒霞客_赤魔王_金赤假龙_玉玉心羽鲈-果酿饵_赤糜饵_飞蝇假饵_酸桔饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 甜甜花鳉、擒霞客、赤魔王、金赤假龙、玉玉心羽鲈\n所需鱼饵: 果酿饵、赤糜饵、飞蝇假饵、酸桔饵\n鱼类详情: \n甜甜花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n金赤假龙(飞蝇假饵)[全天]\n玉玉心羽鲈(酸桔饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2257.07,
+            "y": 934.98,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2297.46,
+            "y": 911.72,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2303.76,
+            "y": 908.06,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-珉林天遒谷-花鳉_水晶宴_斗棘鱼-果酿饵_赤糜饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-珉林天遒谷-花鳉_水晶宴_斗棘鱼-果酿饵_赤糜饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-珉林天遒谷-花鳉_水晶宴_斗棘鱼-果酿饵_赤糜饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、水晶宴、斗棘鱼\n所需鱼饵: 果酿饵、赤糜饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n水晶宴(果酿饵)[白天]\n斗棘鱼(赤糜饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 1152.65,
+            "y": 141.64,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1240.85,
+            "y": 144.33,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 1256.84,
+            "y": 147.91,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 1305.18,
+            "y": 146.47,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 1321.18,
+            "y": 154.93,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 1332.97,
+            "y": 156.51,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 1333.66,
+            "y": 153.75,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-珉林奥藏山-花鳉_甜甜花鳉_擒霞客_水晶宴_长生仙-果酿饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-珉林奥藏山-花鳉_甜甜花鳉_擒霞客_水晶宴_长生仙-果酿饵_蠕虫假饵-普通.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-珉林奥藏山-花鳉_甜甜花鳉_擒霞客_水晶宴_长生仙-果酿饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、甜甜花鳉、擒霞客、水晶宴、长生仙\n所需鱼饵: 果酿饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n甜甜花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n长生仙(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 1602.77,
+            "y": 1039.88,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1591.38,
+            "y": 1038.38,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 1559.01,
+            "y": 1034.23,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 1577.0,
+            "y": 1137.3,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 1579.69,
+            "y": 1144.11,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 1581.16,
+            "y": 1143.09,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-珉林琥牢山东-花鳉_甜甜花鳉_擒霞客_水晶宴_斗棘鱼_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-珉林琥牢山东-花鳉_甜甜花鳉_擒霞客_水晶宴_斗棘鱼_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-珉林琥牢山东-花鳉_甜甜花鳉_擒霞客_水晶宴_斗棘鱼_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、甜甜花鳉、擒霞客、水晶宴、斗棘鱼、流纹褐蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n甜甜花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n斗棘鱼(赤糜饵)[夜晚]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 1794.21,
+            "y": 717.5,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1785.04,
+            "y": 716.3,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 1636.13,
+            "y": 693.77,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(5.5),attack(0.1)"
+        },
+        {
+            "id": 4,
+            "x": 1642.25,
+            "y": 692.99,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-琼玑野归离原东北-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_錆假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-琼玑野归离原东北-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_錆假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-琼玑野归离原东北-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_錆假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 甜甜花鳉、斗棘鱼、赤魔王、金赤假龙、錆假龙、流纹褐蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n甜甜花鳉(果酿饵)[全天]\n斗棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n金赤假龙(飞蝇假饵)[全天]\n錆假龙(飞蝇假饵)[全天]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -57.42,
+            "y": 656.96,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -15.62,
+            "y": 650.45,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 28.93,
+            "y": 656.1,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 53.16,
+            "y": 650.85,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 60.75,
+            "y": 649.3,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 60.36,
+            "y": 647.31,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-琼玑野渌华池-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_錆假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-琼玑野渌华池-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_錆假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-琼玑野渌华池-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_錆假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 甜甜花鳉、斗棘鱼、赤魔王、金赤假龙、錆假龙、流纹褐蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n甜甜花鳉(果酿饵)[全天]\n斗棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n金赤假龙(飞蝇假饵)[全天]\n錆假龙(飞蝇假饵)[全天]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 526.14,
+            "y": 105.78,
+            "action_params": "wait(0.5),keypress(space),wait(0.5)"
+        },
+        {
+            "id": 2,
+            "x": 529.17,
+            "y": 120.12,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 530.63,
+            "y": 129.27,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-碧水原奥藏山东-花鳉_擒霞客_水晶宴_流纹褐蝶鱼-果酿饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-碧水原奥藏山东-花鳉_擒霞客_水晶宴_流纹褐蝶鱼-果酿饵_蠕虫假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-碧水原奥藏山东-花鳉_擒霞客_水晶宴_流纹褐蝶鱼-果酿饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、擒霞客、水晶宴、流纹褐蝶鱼\n所需鱼饵: 果酿饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 1120.98,
+            "y": 1190.4,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1100.11,
+            "y": 1212.37,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 997.33,
+            "y": 1344.07,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 1004.63,
+            "y": 1358.3,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-碧水原望舒客栈西-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_锖假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-碧水原望舒客栈西-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_锖假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,102 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-碧水原望舒客栈西-甜甜花鳉_斗棘鱼_赤魔王_金赤假龙_锖假龙_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 甜甜花鳉、斗棘鱼、赤魔王、金赤假龙、锖假龙、流纹褐蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n甜甜花鳉(果酿饵)[全天]\n斗棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n金赤假龙(飞蝇假饵)[全天]\n锖假龙(飞蝇假饵)[全天]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 730.67,
+            "y": 1062.85,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 708.83,
+            "y": 1040.94,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 662.79,
+            "y": 1006.15,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 635.48,
+            "y": 965.14,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 577.19,
+            "y": 928.74,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 567.61,
+            "y": 926.14,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 562.24,
+            "y": 935.66,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": 558.83,
+            "y": 947.55,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": 548.57,
+            "y": 943.07,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 10,
+            "x": 547.73,
+            "y": 943.55,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-碧水原药蝶谷东-花鳉_斗棘鱼_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-碧水原药蝶谷东-花鳉_斗棘鱼_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-碧水原药蝶谷东-花鳉_斗棘鱼_流纹褐蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、斗棘鱼、流纹褐蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n斗棘鱼(赤糜饵)[夜晚]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 1270.66,
+            "y": 1564.15,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 1186.85,
+            "y": 1544.49,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 1152.12,
+            "y": 1537.31,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 1144.65,
+            "y": 1535.11,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/璃月-垂钓点-碧水原轻策庄东北-甜甜花鳉_擒霞客_水晶宴_斗棘鱼_流纹褐蝶鱼_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/璃月-垂钓点-碧水原轻策庄东北-甜甜花鳉_擒霞客_水晶宴_斗棘鱼_流纹褐蝶鱼_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "璃月-垂钓点-碧水原轻策庄东北-甜甜花鳉_擒霞客_水晶宴_斗棘鱼_流纹褐蝶鱼_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 甜甜花鳉、擒霞客、水晶宴、斗棘鱼、流纹褐蝶鱼、苦炮鲀\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n甜甜花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n斗棘鱼(赤糜饵)[夜晚]\n流纹褐蝶鱼(蠕虫假饵)[白天]\n苦炮鲀(飞蝇假饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 548.38,
+            "y": 1767.06,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 543.8,
+            "y": 1763.76,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 497.21,
+            "y": 1778.69,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 492.01,
+            "y": 1783.56,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 456.39,
+            "y": 1814.77,
+            "type": "target",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "wait(4.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-八酝岛名椎滩北-花鳉_肺棘鱼_流纹京紫蝶鱼_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-八酝岛名椎滩北-花鳉_肺棘鱼_流纹京紫蝶鱼_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-八酝岛名椎滩北-花鳉_肺棘鱼_流纹京紫蝶鱼_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、肺棘鱼、流纹京紫蝶鱼、苦炮鲀\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n肺棘鱼(赤糜饵)[夜晚]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n苦炮鲀(飞蝇假饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -2738.32,
+            "y": -3414.58,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -2722.58,
+            "y": -3402.62,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -2674.26,
+            "y": -3417.0,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -2637.52,
+            "y": -3407.57,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -2619.53,
+            "y": -3416.3,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -2613.13,
+            "y": -3400.58,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -2618.35,
+            "y": -3397.41,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-海祇岛水月池东-花鳉_琉璃花鳉_擒霞客_水晶宴_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-海祇岛水月池东-花鳉_琉璃花鳉_擒霞客_水晶宴_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-海祇岛水月池东-花鳉_琉璃花鳉_擒霞客_水晶宴_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、琉璃花鳉、擒霞客、水晶宴、肺棘鱼、流纹京紫蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n琉璃花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n肺棘鱼(赤糜饵)[夜晚]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -1134.58,
+            "y": -3605.0,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1138.31,
+            "y": -3597.41,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f),wait(1),keypress(t),wait(1),keypress(t),wait(1),keypress(t),wait(1)"
+        },
+        {
+            "id": 3,
+            "x": -1131.4,
+            "y": -3587.05,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1152.04,
+            "y": -3592.3,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -1191.11,
+            "y": -3605.33,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -1243.13,
+            "y": -3568.21,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -1249.62,
+            "y": -3568.81,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-海祇岛珊瑚宫北-花鳉_琉璃花鳉_擒霞客_水晶宴_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-海祇岛珊瑚宫北-花鳉_琉璃花鳉_擒霞客_水晶宴_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-海祇岛珊瑚宫北-花鳉_琉璃花鳉_擒霞客_水晶宴_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、琉璃花鳉、擒霞客、水晶宴、肺棘鱼、流纹京紫蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n琉璃花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n肺棘鱼(赤糜饵)[夜晚]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -765.91,
+            "y": -3557.28,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -770.16,
+            "y": -3565.21,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -831.89,
+            "y": -3637.24,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(2),attack(0.1)"
+        },
+        {
+            "id": 4,
+            "x": -817.84,
+            "y": -3637.46,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-清籁岛天云峠北-花鳉_擒霞客_水晶宴_流纹京紫蝶鱼_炮鲀-果酿饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-清籁岛天云峠北-花鳉_擒霞客_水晶宴_流纹京紫蝶鱼_炮鲀-果酿饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-清籁岛天云峠北-花鳉_擒霞客_水晶宴_流纹京紫蝶鱼_炮鲀-果酿饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、擒霞客、水晶宴、流纹京紫蝶鱼、炮鲀\n所需鱼饵: 果酿饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n炮鲀(飞蝇假饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -4186.05,
+            "y": -4384.52,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4177.89,
+            "y": -4397.05,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4161.24,
+            "y": -4431.81,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(1.5),attack(0.1)"
+        },
+        {
+            "id": 4,
+            "x": -4154.07,
+            "y": -4445.2,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-清籁岛越石村东南-琉璃花鳉_肺棘鱼_赤魔王_金赤假龙_锖假龙_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-清籁岛越石村东南-琉璃花鳉_肺棘鱼_赤魔王_金赤假龙_锖假龙_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-清籁岛越石村东南-琉璃花鳉_肺棘鱼_赤魔王_金赤假龙_锖假龙_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 琉璃花鳉、肺棘鱼、赤魔王、金赤假龙、锖假龙、流纹京紫蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n琉璃花鳉(果酿饵)[全天]\n肺棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n金赤假龙(飞蝇假饵)[全天]\n锖假龙(飞蝇假饵)[全天]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -4023.3,
+            "y": -4428.84,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4032.28,
+            "y": -4430.06,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4052.24,
+            "y": -4439.89,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4057.28,
+            "y": -4437.1,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-神无冢甘金岛南-琉璃花鳉_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-神无冢甘金岛南-琉璃花鳉_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,93 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-神无冢甘金岛南-琉璃花鳉_肺棘鱼_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 琉璃花鳉、肺棘鱼、流纹京紫蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n琉璃花鳉(果酿饵)[全天]\n肺棘鱼(赤糜饵)[夜晚]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -3931.17,
+            "y": -3202.8,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -3911.74,
+            "y": -3211.75,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -3905.86,
+            "y": -3230.8,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -3913.13,
+            "y": -3256.54,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -3927.65,
+            "y": -3256.03,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -3941.39,
+            "y": -3243.48,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -3948.92,
+            "y": -3238.11,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -3953.11,
+            "y": -3234.34,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -3953.94,
+            "y": -3236.88,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-鹤观千来神祠西-花鳉_琉璃花鳉_擒霞客_水晶宴-果酿饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-鹤观千来神祠西-花鳉_琉璃花鳉_擒霞客_水晶宴-果酿饵-普通.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-鹤观千来神祠西-花鳉_琉璃花鳉_擒霞客_水晶宴-果酿饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、琉璃花鳉、擒霞客、水晶宴\n所需鱼饵: 果酿饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n琉璃花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -2811.2,
+            "y": -6048.88,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -2794.82,
+            "y": -6051.81,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -2791.48,
+            "y": -6041.17,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/稻妻-垂钓点-鹤观逢岳之野西南-花鳉_肺棘鱼_赤魔王_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/稻妻-垂钓点-鹤观逢岳之野西南-花鳉_肺棘鱼_赤魔王_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,93 @@
+{
+    "info": {
+        "name": "稻妻-垂钓点-鹤观逢岳之野西南-花鳉_肺棘鱼_赤魔王_流纹京紫蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、肺棘鱼、赤魔王、流纹京紫蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n肺棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n流纹京紫蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -2612.34,
+            "y": -6508.26,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -2606.01,
+            "y": -6504.53,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -2585.35,
+            "y": -6493.05,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -2512.4,
+            "y": -6451.26,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -2463.86,
+            "y": -6447.19,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -2452.94,
+            "y": -6447.46,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -2381.32,
+            "y": -6416.21,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -2375.78,
+            "y": -6425.19,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -2378.45,
+            "y": -6426.49,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-境壁山浮羽之湾东-伪装鲨鲨独角鱼_花鳉_繁花斗士急流鱼_深潜斗士急流鱼_晚霞翻车鲀_青浪翻车鲀-果酿饵_澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-境壁山浮羽之湾东-伪装鲨鲨独角鱼_花鳉_繁花斗士急流鱼_深潜斗士急流鱼_晚霞翻车鲀_青浪翻车鲀-果酿饵_澄晶果粒饵-普通.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-境壁山浮羽之湾东-伪装鲨鲨独角鱼_花鳉_繁花斗士急流鱼_深潜斗士急流鱼_晚霞翻车鲀_青浪翻车鲀-果酿饵_澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 伪装鲨鲨独角鱼、花鳉、繁花斗士急流鱼、深潜斗士急流鱼、晚霞翻车鲀、青浪翻车鲀\n所需鱼饵: 果酿饵、澄晶果粒饵\n鱼类详情: \n伪装鲨鲨独角鱼(澄晶果粒饵)[全天]\n花鳉(果酿饵)[全天]\n繁花斗士急流鱼(澄晶果粒饵)[夜晚]\n深潜斗士急流鱼(澄晶果粒饵)[白天]\n晚霞翻车鲀(澄晶果粒饵)[夜晚]\n青浪翻车鲀(澄晶果粒饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 9970.75,
+            "y": -1605.49,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 10000.27,
+            "y": -1601.03,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 10117.55,
+            "y": -1573.44,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 10132.27,
+            "y": -1589.87,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 10163.63,
+            "y": -1606.48,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 10170.31,
+            "y": -1621.04,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔东-花鳉_青浪翻车鲀_晚霞翻车鲀_伪装鲨鲨独角鱼-果酿饵_澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔东-花鳉_青浪翻车鲀_晚霞翻车鲀_伪装鲨鲨独角鱼-果酿饵_澄晶果粒饵-普通.json
@@ -1,0 +1,94 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-奥奇卡纳塔东-花鳉_青浪翻车鲀_晚霞翻车鲀_伪装鲨鲨独角鱼-果酿饵_澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、青浪翻车鲀、晚霞翻车鲀、伪装鲨鲨独角鱼\n所需鱼饵: 果酿饵、澄晶果粒饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n青浪翻车鲀(澄晶果粒饵)[白天]\n晚霞翻车鲀(澄晶果粒饵)[夜晚]\n伪装鲨鲨独角鱼(澄晶果粒饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 9427.4,
+            "y": -354.51,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 9413.34,
+            "y": -360.54,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 9401.45,
+            "y": -368.02,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 9400.31,
+            "y": -368.45,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 9387.62,
+            "y": -373.02,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 9342.43,
+            "y": -390.33,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 7,
+            "x": 9199.3,
+            "y": -334.7,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": 9193.28,
+            "y": -331.35,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": 9190.6,
+            "y": -334.15,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔北-花鳉_晚霞翻车鲀_伪装鲨鲨独角鱼_深潜斗士急流鱼-果酿饵_澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔北-花鳉_晚霞翻车鲀_伪装鲨鲨独角鱼_深潜斗士急流鱼-果酿饵_澄晶果粒饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-奥奇卡纳塔北-花鳉_晚霞翻车鲀_伪装鲨鲨独角鱼_深潜斗士急流鱼-果酿饵_澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、晚霞翻车鲀、伪装鲨鲨独角鱼、深潜斗士急流鱼\n所需鱼饵: 果酿饵、澄晶果粒饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n晚霞翻车鲀(澄晶果粒饵)[夜晚]\n伪装鲨鲨独角鱼(澄晶果粒饵)[全天]\n深潜斗士急流鱼(澄晶果粒饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 10073.68,
+            "y": 20.94,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 10079.23,
+            "y": 18.04,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 10121.61,
+            "y": -7.64,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 10136.35,
+            "y": -12.29,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 10133.79,
+            "y": -8.54,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(2),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔南-花鳉_繁花斗士急流鱼_深潜斗士急流鱼_青浪翻车鲀_晚霞翻车鲀-果酿饵_澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔南-花鳉_繁花斗士急流鱼_深潜斗士急流鱼_青浪翻车鲀_晚霞翻车鲀-果酿饵_澄晶果粒饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-奥奇卡纳塔南-花鳉_繁花斗士急流鱼_深潜斗士急流鱼_青浪翻车鲀_晚霞翻车鲀-果酿饵_澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、繁花斗士急流鱼、深潜斗士急流鱼、青浪翻车鲀、晚霞翻车鲀\n所需鱼饵: 果酿饵、澄晶果粒饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n繁花斗士急流鱼(澄晶果粒饵)[夜晚]\n深潜斗士急流鱼(澄晶果粒饵)[白天]\n青浪翻车鲀(澄晶果粒饵)[白天]\n晚霞翻车鲀(澄晶果粒饵)[夜晚]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 9715.53,
+            "y": -847.85,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": 9720.81,
+            "y": -862.49,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": 9722.94,
+            "y": -881.93,
+            "action": "combat_script",
+            "move_mode": "fly",
+            "action_params": "keypress(space),wait(1.5),attack(0.1)",
+            "type": "path"
+        },
+        {
+            "id": 4,
+            "x": 9722.97,
+            "y": -888.04,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.5),keypress(f)",
+            "type": "path"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔西-深潜斗士急流鱼_繁花斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-奥奇卡纳塔西-深潜斗士急流鱼_繁花斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-普通.json
@@ -1,0 +1,84 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-奥奇卡纳塔西-深潜斗士急流鱼_繁花斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 深潜斗士急流鱼、繁花斗士急流鱼、伪装鲨鲨独角鱼\n所需鱼饵: 澄晶果粒饵\n鱼类详情: \n深潜斗士急流鱼(澄晶果粒饵)[白天]\n繁花斗士急流鱼(澄晶果粒饵)[夜晚]\n伪装鲨鲨独角鱼(澄晶果粒饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 10163.09,
+            "y": -398.85,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 10245.02,
+            "y": -392.27,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 10264.41,
+            "y": -390.43,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 10276.46,
+            "y": -388.09,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 10316.22,
+            "y": -420.1,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 10313.9,
+            "y": -443.41,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 10314.94,
+            "y": -476.15,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": 10326.14,
+            "y": -491.12,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(2),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-翘枝崖花羽会北-晚霞翻车鲀_深潜斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-翘枝崖花羽会北-晚霞翻车鲀_深潜斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-翘枝崖花羽会北-晚霞翻车鲀_深潜斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 晚霞翻车鲀、深潜斗士急流鱼、伪装鲨鲨独角鱼\n所需鱼饵: 澄晶果粒饵\n鱼类详情: \n晚霞翻车鲀(澄晶果粒饵)[夜晚]\n深潜斗士急流鱼(澄晶果粒饵)[白天]\n伪装鲨鲨独角鱼(澄晶果粒饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 9548.26,
+            "y": -1116.55,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 9556.78,
+            "y": -1105.44,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 9570.33,
+            "y": -1059.8,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(3.5),attack(0.1)"
+        },
+        {
+            "id": 4,
+            "x": 9574.55,
+            "y": -1051.32,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/纳塔-垂钓点-翘枝崖花羽会西-花鳉_繁花斗士急流鱼_深潜斗士急流鱼_晚霞翻车鲀_伪装鲨鲨独角鱼-果酿饵_澄晶果粒饵-普通.json
+++ b/repo/pathing/垂钓点/纳塔-垂钓点-翘枝崖花羽会西-花鳉_繁花斗士急流鱼_深潜斗士急流鱼_晚霞翻车鲀_伪装鲨鲨独角鱼-果酿饵_澄晶果粒饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "纳塔-垂钓点-翘枝崖花羽会西-花鳉_繁花斗士急流鱼_深潜斗士急流鱼_晚霞翻车鲀_伪装鲨鲨独角鱼-果酿饵_澄晶果粒饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、繁花斗士急流鱼、深潜斗士急流鱼、晚霞翻车鲀、伪装鲨鲨独角鱼\n所需鱼饵: 果酿饵、澄晶果粒饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n繁花斗士急流鱼(澄晶果粒饵)[夜晚]\n深潜斗士急流鱼(澄晶果粒饵)[白天]\n晚霞翻车鲀(澄晶果粒饵)[夜晚]\n伪装鲨鲨独角鱼(澄晶果粒饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 9839.55,
+            "y": -1290.0,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 9878.25,
+            "y": -1226.13,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 9938.91,
+            "y": -1197.05,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 9933.82,
+            "y": -1175.72,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-坠星山谷低语森林南-蓝染花鳉_水晶宴_鸩棘鱼_锖假龙_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-坠星山谷低语森林南-蓝染花鳉_水晶宴_鸩棘鱼_锖假龙_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-坠星山谷低语森林南-蓝染花鳉_水晶宴_鸩棘鱼_锖假龙_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 蓝染花鳉、水晶宴、鸩棘鱼、锖假龙、流纹茶蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n蓝染花鳉(果酿饵)[全天]\n水晶宴(果酿饵)[白天]\n鸩棘鱼(赤糜饵)[夜晚]\n锖假龙(飞蝇假饵)[全天]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -1119.85,
+            "y": 2190.36,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1120.04,
+            "y": 2202.13,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -1110.19,
+            "y": 2229.83,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1083.67,
+            "y": 2280.98,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -1072.24,
+            "y": 2281.29,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-坠星山谷望风山地-花鳉_蓝染花鳉_擒霞客_水晶宴_鸩棘鱼_金赤假龙_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-坠星山谷望风山地-花鳉_蓝染花鳉_擒霞客_水晶宴_鸩棘鱼_金赤假龙_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-坠星山谷望风山地-花鳉_蓝染花鳉_擒霞客_水晶宴_鸩棘鱼_金赤假龙_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、蓝染花鳉、擒霞客、水晶宴、鸩棘鱼、金赤假龙、流纹茶蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n蓝染花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n鸩棘鱼(赤糜饵)[夜晚]\n金赤假龙(飞蝇假饵)[全天]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -1273.76,
+            "y": 2721.67,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1295.05,
+            "y": 2733.4,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -1329.33,
+            "y": 2733.96,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1331.29,
+            "y": 2743.07,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-明冠山地风龙废墟北-花鳉_蓝染花鳉_擒霞客_水晶宴-果酿饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-明冠山地风龙废墟北-花鳉_蓝染花鳉_擒霞客_水晶宴-果酿饵-普通.json
@@ -1,0 +1,84 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-明冠山地风龙废墟北-花鳉_蓝染花鳉_擒霞客_水晶宴-果酿饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、蓝染花鳉、擒霞客、水晶宴\n所需鱼饵: 果酿饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n蓝染花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n水晶宴(果酿饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 265.65,
+            "y": 2914.79,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 195.72,
+            "y": 2919.42,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 126.32,
+            "y": 2909.81,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 77.14,
+            "y": 2925.38,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 56.73,
+            "y": 2905.74,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 56.18,
+            "y": 2897.43,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 55.63,
+            "y": 2891.88,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": 59.92,
+            "y": 2889.84,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-明冠山地风龙废墟南-花鳉_蓝染花鳉_擒霞客_流纹茶蝶鱼-果酿饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-明冠山地风龙废墟南-花鳉_蓝染花鳉_擒霞客_流纹茶蝶鱼-果酿饵_蠕虫假饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-明冠山地风龙废墟南-花鳉_蓝染花鳉_擒霞客_流纹茶蝶鱼-果酿饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、蓝染花鳉、擒霞客、流纹茶蝶鱼\n所需鱼饵: 果酿饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n蓝染花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 36.79,
+            "y": 2380.88,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 43.66,
+            "y": 2402.59,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 64.42,
+            "y": 2458.77,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 69.64,
+            "y": 2461.92,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 120.44,
+            "y": 2483.32,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 129.49,
+            "y": 2486.39,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 127.23,
+            "y": 2488.91,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-苍风高地晨曦酒庄西南-蓝染花鳉_擒霞客_鸩棘鱼_赤魔王_流纹茶蝶鱼_炮鲀_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-苍风高地晨曦酒庄西南-蓝染花鳉_擒霞客_鸩棘鱼_赤魔王_流纹茶蝶鱼_炮鲀_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-苍风高地晨曦酒庄西南-蓝染花鳉_擒霞客_鸩棘鱼_赤魔王_流纹茶蝶鱼_炮鲀_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 蓝染花鳉、擒霞客、鸩棘鱼、赤魔王、流纹茶蝶鱼、炮鲀、苦炮鲀\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n蓝染花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n鸩棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n炮鲀(飞蝇假饵)[全天]\n苦炮鲀(飞蝇假饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -321.65,
+            "y": 1472.26,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -324.01,
+            "y": 1493.99,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -325.27,
+            "y": 1532.57,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -314.55,
+            "y": 1557.49,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -288.38,
+            "y": 1598.5,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -234.18,
+            "y": 1704.54,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -240.91,
+            "y": 1703.85,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-苍风高地清泉镇北-花鳉_蓝染花鳉_鸩棘鱼_赤魔王_流纹茶蝶鱼_炮鲀_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-苍风高地清泉镇北-花鳉_蓝染花鳉_鸩棘鱼_赤魔王_流纹茶蝶鱼_炮鲀_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-苍风高地清泉镇北-花鳉_蓝染花鳉_鸩棘鱼_赤魔王_流纹茶蝶鱼_炮鲀_苦炮鲀-果酿饵_赤糜饵_蠕虫假饵_飞蝇假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、蓝染花鳉、鸩棘鱼、赤魔王、流纹茶蝶鱼、炮鲀、苦炮鲀\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵、飞蝇假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n蓝染花鳉(果酿饵)[全天]\n鸩棘鱼(赤糜饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n炮鲀(飞蝇假饵)[全天]\n苦炮鲀(飞蝇假饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -868.42,
+            "y": 1991.78,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -838.38,
+            "y": 2031.1,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -831.54,
+            "y": 2031.18,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -803.01,
+            "y": 2039.03,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -803.65,
+            "y": 2042.02,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-风啸山坡风起地南-花鳉_蓝染花鳉_鸩棘鱼_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-风啸山坡风起地南-花鳉_蓝染花鳉_鸩棘鱼_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-风啸山坡风起地南-花鳉_蓝染花鳉_鸩棘鱼_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、蓝染花鳉、鸩棘鱼、流纹茶蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n蓝染花鳉(果酿饵)[全天]\n鸩棘鱼(赤糜饵)[夜晚]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -1266.77,
+            "y": 1935.64,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1250.62,
+            "y": 1912.66,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -1256.09,
+            "y": 1882.18,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1259.25,
+            "y": 1868.69,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -1256.0,
+            "y": 1845.8,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -1267.6,
+            "y": 1834.11,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -1270.13,
+            "y": 1841.21,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/蒙德-垂钓点-龙脊雪山寒天之钉西-花鳉_鸩棘鱼_雪中君_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
+++ b/repo/pathing/垂钓点/蒙德-垂钓点-龙脊雪山寒天之钉西-花鳉_鸩棘鱼_雪中君_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "蒙德-垂钓点-龙脊雪山寒天之钉西-花鳉_鸩棘鱼_雪中君_流纹茶蝶鱼-果酿饵_赤糜饵_蠕虫假饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、鸩棘鱼、雪中君、流纹茶蝶鱼\n所需鱼饵: 果酿饵、赤糜饵、蠕虫假饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n鸩棘鱼(赤糜饵)[夜晚]\n雪中君(赤糜饵)[夜晚]\n流纹茶蝶鱼(蠕虫假饵)[白天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -705.5,
+            "y": 925.62,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -687.73,
+            "y": 926.62,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -604.83,
+            "y": 1006.54,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -605.82,
+            "y": 995.64,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-下风蚀地活力之家西南-花鳉_擒霞客_赤魔王_真果角鲀_青金斧枪鱼-果酿饵_赤糜饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-下风蚀地活力之家西南-花鳉_擒霞客_赤魔王_真果角鲀_青金斧枪鱼-果酿饵_赤糜饵_甘露饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-下风蚀地活力之家西南-花鳉_擒霞客_赤魔王_真果角鲀_青金斧枪鱼-果酿饵_赤糜饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、擒霞客、赤魔王、真果角鲀、青金斧枪鱼\n所需鱼饵: 果酿饵、赤糜饵、甘露饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n擒霞客(果酿饵)[夜晚]\n赤魔王(赤糜饵)[白天]\n真果角鲀(甘露饵)[白天]\n青金斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 4036.27,
+            "y": -2464.92,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4043.97,
+            "y": -2471.61,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4187.01,
+            "y": -2484.1,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(1.5),attack(0.1)"
+        },
+        {
+            "id": 4,
+            "x": 4187.15,
+            "y": -2487.58,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-下风蚀地阿如村-花鳉_水晶宴_吹沙角鲀_暮云角鲀_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-下风蚀地阿如村-花鳉_水晶宴_吹沙角鲀_暮云角鲀_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-下风蚀地阿如村-花鳉_水晶宴_吹沙角鲀_暮云角鲀_翡玉斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、水晶宴、吹沙角鲀、暮云角鲀、翡玉斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n水晶宴(果酿饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 4096.01,
+            "y": -2025.96,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4106.81,
+            "y": -2002.15,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4125.62,
+            "y": -1995.95,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4142.21,
+            "y": -1984.34,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 4166.21,
+            "y": -1957.38,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(3),attack(0.1)"
+        },
+        {
+            "id": 6,
+            "x": 4163.05,
+            "y": -1960.71,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-千壑沙地「五绿洲」的孑遗-真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-千壑沙地「五绿洲」的孑遗-真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-甘露饵-普通.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-千壑沙地「五绿洲」的孑遗-真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 真果角鲀、吹沙角鲀、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 甘露饵\n鱼类详情: \n真果角鲀(甘露饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 4693.99,
+            "y": -261.94,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 4704.69,
+            "y": -260.78,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 4735.3,
+            "y": -219.63,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 4740.08,
+            "y": -214.55,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "up_down_grab_leaf",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 4760.5,
+            "y": -201.04,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "up_down_grab_leaf",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 4811.19,
+            "y": -178.01,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 4812.44,
+            "y": -179.03,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-护世森无郁稠林-沉波蜜桃_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-护世森无郁稠林-沉波蜜桃_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-甘露饵-普通.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-护世森无郁稠林-沉波蜜桃_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 沉波蜜桃、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 甘露饵\n鱼类详情: \n沉波蜜桃(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2409.72,
+            "y": 348.87,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2378.21,
+            "y": 389.62,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2376.1,
+            "y": 398.08,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-桓那兰那觉王之殿北-花鳉_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-桓那兰那觉王之殿北-花鳉_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,84 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-桓那兰那觉王之殿北-花鳉_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、真果角鲀、吹沙角鲀、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n真果角鲀(甘露饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3705.6,
+            "y": -497.39,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3704.45,
+            "y": -480.43,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 3617.2,
+            "y": -344.13,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3617.05,
+            "y": -308.78,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 3605.56,
+            "y": -284.52,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": 3593.31,
+            "y": -279.98,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": 3580.85,
+            "y": -282.59,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": 3575.66,
+            "y": -289.49,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-荒石苍漠铁穆山南-擒霞客_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-荒石苍漠铁穆山南-擒霞客_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-荒石苍漠铁穆山南-擒霞客_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 擒霞客、真果角鲀、吹沙角鲀、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n擒霞客(果酿饵)[夜晚]\n真果角鲀(甘露饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 6160.72,
+            "y": 1.78,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 6152.95,
+            "y": 37.69,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 6145.48,
+            "y": 124.97,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 6142.97,
+            "y": 120.54,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-道成林天臂池-赤魔王_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-赤糜饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-道成林天臂池-赤魔王_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-赤糜饵_甘露饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-道成林天臂池-赤魔王_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-赤糜饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 赤魔王、真果角鲀、吹沙角鲀、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 赤糜饵、甘露饵\n鱼类详情: \n赤魔王(赤糜饵)[白天]\n真果角鲀(甘露饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3067.82,
+            "y": -713.74,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3048.36,
+            "y": -708.72,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2863.74,
+            "y": -697.84,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 2863.58,
+            "y": -690.26,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-道成林维摩庄北-花鳉_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-道成林维摩庄北-花鳉_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-道成林维摩庄北-花鳉_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 花鳉、真果角鲀、吹沙角鲀、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n花鳉(果酿饵)[全天]\n真果角鲀(甘露饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2631.91,
+            "y": -1016.91,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2642.24,
+            "y": -1008.33,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2645.78,
+            "y": -1011.84,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-道成林须弥城南-擒霞客_吹沙角鲀_暮云角鲀_青金斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-道成林须弥城南-擒霞客_吹沙角鲀_暮云角鲀_青金斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-道成林须弥城南-擒霞客_吹沙角鲀_暮云角鲀_青金斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 擒霞客、吹沙角鲀、暮云角鲀、青金斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n擒霞客(果酿饵)[夜晚]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2786.98,
+            "y": -503.11,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2790.81,
+            "y": -504.81,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2844.24,
+            "y": -519.8,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 2847.21,
+            "y": -516.12,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-阿陀河谷奥摩斯港北-水晶宴_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-阿陀河谷奥摩斯港北-水晶宴_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-阿陀河谷奥摩斯港北-水晶宴_真果角鲀_吹沙角鲀_暮云角鲀_青金斧枪鱼_翡玉斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 水晶宴、真果角鲀、吹沙角鲀、暮云角鲀、青金斧枪鱼、翡玉斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n水晶宴(果酿饵)[白天]\n真果角鲀(甘露饵)[白天]\n吹沙角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n青金斧枪鱼(甘露饵)[全天]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2567.48,
+            "y": -1424.06,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2540.23,
+            "y": -1664.57,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 2533.5,
+            "y": -1675.29,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 2545.12,
+            "y": -1686.21,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/垂钓点/须弥-垂钓点-阿陀河谷降诸魔山-擒霞客_真果角鲀_暮云角鲀_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
+++ b/repo/pathing/垂钓点/须弥-垂钓点-阿陀河谷降诸魔山-擒霞客_真果角鲀_暮云角鲀_翡玉斧枪鱼-果酿饵_甘露饵-普通.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "须弥-垂钓点-阿陀河谷降诸魔山-擒霞客_真果角鲀_暮云角鲀_翡玉斧枪鱼-果酿饵_甘露饵-普通.json",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "出没鱼类: 擒霞客、真果角鲀、暮云角鲀、翡玉斧枪鱼\n所需鱼饵: 果酿饵、甘露饵\n鱼类详情: \n擒霞客(果酿饵)[夜晚]\n真果角鲀(甘露饵)[白天]\n暮云角鲀(甘露饵)[夜晚]\n翡玉斧枪鱼(甘露饵)[全天]\n\n特殊属性(供JS脚本识别): 普通",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 2288.82,
+            "y": -1197.56,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 2315.55,
+            "y": -1281.99,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(2),attack(0.1)"
+        },
+        {
+            "id": 3,
+            "x": 2319.11,
+            "y": -1286.9,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛曚云神社东北-3个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛曚云神社东北-3个.json
@@ -1,0 +1,58 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛曚云神社东北-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n稻妻-海祇岛曚云神社东北",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -575.24,
+            "y": -3832.12,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -601.64,
+            "y": -3813.76,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -603.15,
+            "y": -3757.91,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -604.25,
+            "y": -3721.16,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(2.5),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 5,
+            "x": -604.25,
+            "y": -3721.16,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛曚云神社东南-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛曚云神社东南-4个.json
@@ -1,0 +1,67 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛曚云神社东南-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-海祇岛曚云神社东南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -575.32,
+            "y": -3832.06,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -582.69,
+            "y": -3841.9,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -615.43,
+            "y": -3879.13,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -624.27,
+            "y": -3889.26,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -670.65,
+            "y": -3900.15,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(2.5),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 6,
+            "x": -670.65,
+            "y": -3900.15,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛曚云神社西南-3个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛曚云神社西南-3个.json
@@ -1,0 +1,85 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛曚云神社西南-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n稻妻-海祇岛曚云神社西南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -575.33,
+            "y": -3832.18,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -577.47,
+            "y": -3856.07,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -533.09,
+            "y": -3863.12,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -506.7,
+            "y": -3876.14,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -492.03,
+            "y": -3877.09,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -404.11,
+            "y": -3963.58,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -413.26,
+            "y": -3967.95,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 8,
+            "x": -413.26,
+            "y": -3967.95,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛望泷村东-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛望泷村东-4个.json
@@ -1,0 +1,93 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛望泷村东-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-海祇岛望泷村东",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -1057.75,
+            "y": -3946.08,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1042.9,
+            "y": -3950.33,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -1041.73,
+            "y": -3969.88,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1052.36,
+            "y": -3985.58,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -1032.96,
+            "y": -3998.17,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -1025.61,
+            "y": -4004.42,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -1000.61,
+            "y": -4026.91,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -987.74,
+            "y": -4035.2,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -962.49,
+            "y": -4051.28,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛望泷村南-2个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛望泷村南-2个.json
@@ -1,0 +1,66 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛望泷村南-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-2个\n稻妻-海祇岛望泷村南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -755.58,
+            "y": -4001.08,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -752.68,
+            "y": -4011.0,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -773.27,
+            "y": -4053.43,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -789.89,
+            "y": -4074.93,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -837.28,
+            "y": -4079.26,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -836.44,
+            "y": -4085.17,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛望泷村西南-2个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛望泷村西南-2个.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛望泷村西南-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-2个\n稻妻-海祇岛望泷村西南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -755.58,
+            "y": -4001.08,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -737.78,
+            "y": -4020.82,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -706.1,
+            "y": -4062.17,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -693.4,
+            "y": -4068.5,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛水月池东南-2个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛水月池东南-2个.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛水月池东南-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-2个\n稻妻-海祇岛水月池东南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -1315.18,
+            "y": -3776.18,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1328.35,
+            "y": -3770.05,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -1336.42,
+            "y": -3742.58,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1327.31,
+            "y": -3734.34,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛水月池南-8个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛水月池南-8个.json
@@ -1,0 +1,93 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛水月池南-8个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-8个\n稻妻-海祇岛水月池南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -1057.78,
+            "y": -3946.02,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -1107.87,
+            "y": -3969.65,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -1125.79,
+            "y": -3963.92,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1142.7,
+            "y": -3975.49,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -1162.67,
+            "y": -4003.47,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -1164.43,
+            "y": -4025.8,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -1143.83,
+            "y": -4069.67,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -1141.78,
+            "y": -4086.05,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -1141.57,
+            "y": -4076.93,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫下东北-2个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫下东北-2个.json
@@ -1,0 +1,49 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛珊瑚宫下东北-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-2个\n稻妻-海祇岛珊瑚宫下东北",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -757.97,
+            "y": -3815.17,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -770.6,
+            "y": -3800.12,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -790.48,
+            "y": -3784.76,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(1.5),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -790.48,
+            "y": -3784.76,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫东北岸边-3个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫东北岸边-3个.json
@@ -1,0 +1,76 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛珊瑚宫东北岸边-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n稻妻-海祇岛珊瑚宫东北岸边",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -757.97,
+            "y": -3815.17,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -822.42,
+            "y": -3814.07,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -846.7,
+            "y": -3770.88,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -846.7,
+            "y": -3770.88,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -850.46,
+            "y": -3760.23,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -869.92,
+            "y": -3731.4,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -882.79,
+            "y": -3697.15,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫东北崖下-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫东北崖下-4个.json
@@ -1,0 +1,111 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛珊瑚宫东北崖下-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-海祇岛珊瑚宫东北崖下",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -757.97,
+            "y": -3815.17,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -769.73,
+            "y": -3800.62,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -910.09,
+            "y": -3733.72,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -914.88,
+            "y": -3741.8,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -936.53,
+            "y": -3734.42,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -937.33,
+            "y": -3706.85,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -926.06,
+            "y": -3698.35,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -912.91,
+            "y": -3686.0,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -909.75,
+            "y": -3672.21,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 10,
+            "x": -933.88,
+            "y": -3656.49,
+            "type": "path",
+            "move_mode": "swim",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 11,
+            "x": -929.94,
+            "y": -3647.03,
+            "type": "path",
+            "move_mode": "run",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫北-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-海祇岛珊瑚宫北-4个.json
@@ -1,0 +1,68 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-海祇岛珊瑚宫北-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-海祇岛珊瑚宫北",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -765.98,
+            "y": -3557.24,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -769.96,
+            "y": -3564.63,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -784.29,
+            "y": -3570.99,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(1),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -784.29,
+            "y": -3570.99,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -782.45,
+            "y": -3581.9,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 6,
+            "x": -782.45,
+            "y": -3581.9,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠东-6个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠东-6个.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛天云峠东-6个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-6个\n稻妻-清籁岛天云峠东",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4472.35,
+            "y": -4577.4,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4500.58,
+            "y": -4610.55,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4475.76,
+            "y": -4594.53,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4421.69,
+            "y": -4589.95,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠东南山边-11个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠东南山边-11个.json
@@ -1,0 +1,148 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛天云峠东南山边-11个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-11个\n稻妻-清籁岛天云峠东南山边",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4251.9,
+            "y": -4785.47,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4259.14,
+            "y": -4798.14,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4265.04,
+            "y": -4795.52,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4604.69,
+            "y": -4858.69,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(6.5),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 5,
+            "x": -4604.69,
+            "y": -4858.69,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -4618.78,
+            "y": -4884.13,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -4633.72,
+            "y": -4896.07,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -4614.88,
+            "y": -4949.79,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -4626.31,
+            "y": -4954.96,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 10,
+            "x": -4652.55,
+            "y": -4959.92,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 11,
+            "x": -4646.89,
+            "y": -4972.21,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 12,
+            "x": -4656.19,
+            "y": -4994.82,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 13,
+            "x": -4686.43,
+            "y": -4967.72,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 14,
+            "x": -4707.0,
+            "y": -4975.41,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 15,
+            "x": -4698.26,
+            "y": -4960.75,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠东南岸边-7个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠东南岸边-7个.json
@@ -1,0 +1,85 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛天云峠东南岸边-7个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-7个\n稻妻-清籁岛天云峠东南岸边",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4251.9,
+            "y": -4785.47,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4267.29,
+            "y": -4796.95,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4473.14,
+            "y": -4778.98,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(8),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -4473.14,
+            "y": -4778.98,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -4503.19,
+            "y": -4769.03,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -4526.31,
+            "y": -4746.72,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -4535.75,
+            "y": -4756.05,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -4526.37,
+            "y": -4748.79,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠南-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠南-4个.json
@@ -1,0 +1,67 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛天云峠南-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-清籁岛天云峠南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4251.9,
+            "y": -4785.47,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4340.16,
+            "y": -5078.3,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(2),attack(7.3)",
+            "locked": false
+        },
+        {
+            "id": 3,
+            "x": -4340.16,
+            "y": -5078.3,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4286.04,
+            "y": -5082.16,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -4267.21,
+            "y": -5100.3,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -4238.05,
+            "y": -5107.85,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠西-21个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛天云峠西-21个.json
@@ -1,0 +1,238 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛天云峠西-21个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-21个\n稻妻-清籁岛天云峠西",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4251.9,
+            "y": -4785.47,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4192.62,
+            "y": -4853.83,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "keypress(space),wait(9.5),attack(0.1)",
+            "locked": false
+        },
+        {
+            "id": 3,
+            "x": -4192.62,
+            "y": -4853.83,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4203.23,
+            "y": -4870.79,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -4215.12,
+            "y": -4912.61,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -4189.94,
+            "y": -4920.99,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -4158.4,
+            "y": -4911.34,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 8,
+            "x": -4139.71,
+            "y": -4891.1,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -4125.53,
+            "y": -4861.27,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 10,
+            "x": -4105.56,
+            "y": -4846.81,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 11,
+            "x": -4068.17,
+            "y": -4768.88,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 12,
+            "x": -4051.08,
+            "y": -4734.14,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 13,
+            "x": -4027.03,
+            "y": -4742.99,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 14,
+            "x": -4021.22,
+            "y": -4790.41,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 15,
+            "x": -4035.34,
+            "y": -4845.36,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 16,
+            "x": -4038.62,
+            "y": -4862.56,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 17,
+            "x": -4028.04,
+            "y": -4892.46,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 18,
+            "x": -4046.23,
+            "y": -4895.03,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 19,
+            "x": -4052.64,
+            "y": -4924.83,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 20,
+            "x": -4026.63,
+            "y": -4933.07,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 21,
+            "x": -3999.33,
+            "y": -4925.65,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 22,
+            "x": -3984.65,
+            "y": -4905.64,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 23,
+            "x": -3947.31,
+            "y": -4880.08,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 24,
+            "x": -3924.34,
+            "y": -4835.9,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 25,
+            "x": -3916.26,
+            "y": -4804.97,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛平海砦-5个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛平海砦-5个.json
@@ -1,0 +1,67 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛平海砦-5个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-5个\n稻妻-清籁岛平海砦",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -4185.88,
+            "y": -4383.65,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4173.75,
+            "y": -4367.89,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4190.51,
+            "y": -4369.1,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4223.54,
+            "y": -4371.3,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -4264.77,
+            "y": -4347.55,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 6,
+            "x": -4264.77,
+            "y": -4347.55,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛平海砦西北岸边-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛平海砦西北岸边-4个.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛平海砦西北岸边-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-清籁岛平海砦西北岸边",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4184.89,
+            "y": -4244.61,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4221.02,
+            "y": -4205.94,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4215.21,
+            "y": -4192.04,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4289.32,
+            "y": -4170.13,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "combat_script",
+            "action_params": "wait(0.5),keypress(f)"
+        },
+        {
+            "id": 5,
+            "x": -4306.43,
+            "y": -4156.12,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛平海砦西崖下-4个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛平海砦西崖下-4个.json
@@ -1,0 +1,48 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛平海砦西崖下-4个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-4个\n稻妻-清籁岛平海砦西崖下",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": -4184.89,
+            "y": -4244.61,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -4173.3,
+            "y": -4255.67,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -4169.02,
+            "y": -4275.33,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -4162.3,
+            "y": -4280.14,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛浅濑神社北-3个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛浅濑神社北-3个.json
@@ -1,0 +1,75 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛浅濑神社北-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n稻妻-清籁岛浅濑神社北",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -3891.58,
+            "y": -4389.9,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -3883.05,
+            "y": -4397.65,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -3801.83,
+            "y": -4458.79,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -3806.35,
+            "y": -4468.45,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -3781.69,
+            "y": -4511.29,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 6,
+            "x": -3732.74,
+            "y": -4512.06,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 7,
+            "x": -3732.6,
+            "y": -4522.87,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛越石村南-2个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛越石村南-2个.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛越石村南-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-2个\n稻妻-清籁岛越石村南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -3891.58,
+            "y": -4389.9,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -3887.35,
+            "y": -4399.16,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -3884.15,
+            "y": -4405.37,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -3933.01,
+            "y": -4454.95,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -3947.58,
+            "y": -4473.72,
+            "type": "path",
+            "move_mode": "run",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛越石村西北-3个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-清籁岛越石村西北-3个.json
@@ -1,0 +1,39 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-清籁岛越石村西北-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n稻妻-清籁岛越石村西北",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -3891.58,
+            "y": -4389.9,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -3844.5,
+            "y": -4299.21,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -3836.77,
+            "y": -4271.84,
+            "type": "path",
+            "move_mode": "run",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/稻妻-飘浮灵-鹤观惑饲滩西南-3个.json
+++ b/repo/pathing/飘浮灵/稻妻-飘浮灵-鹤观惑饲滩西南-3个.json
@@ -1,0 +1,49 @@
+{
+    "info": {
+        "name": "稻妻-飘浮灵-鹤观惑饲滩西南-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n稻妻-鹤观惑饲滩西南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": -2598.39,
+            "y": -6690.47,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": -2639.61,
+            "y": -6710.7,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": -2653.14,
+            "y": -6721.37,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -2653.14,
+            "y": -6721.37,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/须弥-飘浮灵-二净甸桓那兰那西南-3个.json
+++ b/repo/pathing/飘浮灵/须弥-飘浮灵-二净甸桓那兰那西南-3个.json
@@ -1,0 +1,49 @@
+{
+    "info": {
+        "name": "须弥-飘浮灵-二净甸桓那兰那西南-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-3个\n须弥-二净甸桓那兰那西南",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "x": 3705.63,
+            "y": -497.33,
+            "type": "teleport",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3704.17,
+            "y": -480.01,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 3639.12,
+            "y": -372.67,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "stop_flying",
+            "action_params": "",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": 3639.12,
+            "y": -372.67,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/飘浮灵/须弥-飘浮灵-二净甸觉王之殿东-6个.json
+++ b/repo/pathing/飘浮灵/须弥-飘浮灵-二净甸觉王之殿东-6个.json
@@ -1,0 +1,57 @@
+{
+    "info": {
+        "name": "须弥-飘浮灵-二净甸觉王之殿东-6个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.0",
+        "description": "飘浮灵-6个\n须弥-二净甸觉王之殿东",
+        "bgiVersion": "0.42.0"
+    },
+    "positions": [
+        {
+            "id": 1,
+            "action": "",
+            "move_mode": "walk",
+            "type": "teleport",
+            "x": 3491.1,
+            "y": -598.89,
+            "action_params": ""
+        },
+        {
+            "id": 2,
+            "x": 3451.08,
+            "y": -619.57,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 3427.66,
+            "y": -607.43,
+            "type": "path",
+            "move_mode": "walk",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": 3406.33,
+            "y": -605.97,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": 3402.29,
+            "y": -593.3,
+            "type": "path",
+            "move_mode": "dash",
+            "action": "fight",
+            "action_params": ""
+        }
+    ]
+}

--- a/repo/pathing/骗骗花/璃月-骗骗花-云来海孤云阁东方崖上和南方岸边-2个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-云来海孤云阁东方崖上和南方岸边-2个.json
@@ -3,7 +3,7 @@
         "name": "璃月-骗骗花-云来海孤云阁东方崖上和南方岸边-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n璃月-云来海孤云阁东方崖上和南方岸边",
         "bgiVersion": "0.42.0"
     },

--- a/repo/pathing/骗骗花/璃月-骗骗花-层岩巨渊巨渊之口东南-6个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-层岩巨渊巨渊之口东南-6个.json
@@ -3,7 +3,7 @@
         "name": "璃月-骗骗花-层岩巨渊巨渊之口东南-6个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-6个\n璃月-层岩巨渊巨渊之口东南",
         "bgiVersion": "0.42.0"
     },

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山南方-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山南方-1个.json
@@ -3,7 +3,7 @@
         "name": "璃月-骗骗花-珉林奥藏山南方-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林奥藏山南方",
         "bgiVersion": "0.42.0"
     },

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山西南方-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山西南方-1个.json
@@ -3,7 +3,7 @@
         "name": "璃月-骗骗花-珉林奥藏山西南方-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林奥藏山西南方",
         "bgiVersion": "0.42.0"
     },

--- a/repo/pathing/骗骗花/稻妻-骗骗花-八酝岛蛇神之首西南-3个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-八酝岛蛇神之首西南-3个.json
@@ -3,7 +3,7 @@
         "name": "稻妻-骗骗花-八酝岛蛇神之首西南-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n稻妻-八酝岛蛇神之首西南",
         "bgiVersion": "0.42.0"
     },

--- a/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个.json
@@ -3,7 +3,7 @@
         "name": "稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-5个\n稻妻-海祇岛珊瑚宫北方略偏西",
         "bgiVersion": "0.42.0"
     },


### PR DESCRIPTION
路径追踪：骗骗花[补充]
更正了版号

路径追踪：飘浮灵
包含26个飘浮灵路径追踪文件（总计123个飘浮灵）
一个飘浮灵路径（须弥-列柱沙原避让之丘北-3个）因为地图特征点过少无法使用[该路径已经排除]

路径追踪:：垂钓点
包含提瓦特全部垂钓点【标明了每个钓鱼点包含的鱼类和所需鱼饵，包含每个鱼类对应的出没时间和所需鱼饵】（以下7个除外[JS脚本预计加入]）
一、5个需要调用键鼠脚本的地下或地图无法识别的点位
1.枫丹-垂钓点-枫丹廷区枫丹廷东北-海涛斧枪鱼_波波心羽鲈_烘烘心羽鲈_维护机关·水域清理者_维护机关·态势控制者-甘露饵_酸橘饵_维护机关频闪诱饵-GCM
2.枫丹-垂钓点-枫丹廷区枫丹廷南-花鳉_海涛斧枪鱼_维护机关·水域清理者_维护机关·态势控制者-果酿饵_甘露饵_维护机关频闪诱饵-GCM
3.纳塔-垂钓点-奥奇卡纳塔西-拟似燃素独角鱼_炽岩斗士急流鱼-温火饵-GCM
4.纳塔-垂钓点-距石山祖遗庙宇东-炽岩斗士急流鱼_拟似燃素独角鱼-温火饵-GCM
5.纳塔-垂钓点-涌流地溶水域-炽岩斗士急流鱼_拟似燃素独角鱼-温火饵-GCM
二、3个需要战斗的点位
1.璃月-垂钓点-碧水原无妄坡南-花鳉_甜甜花鳉_擒霞客_流纹褐蝶鱼-果酿饵_蠕虫假饵-战斗
2.纳塔-垂钓点-奥奇卡纳塔东北-青浪翻车鲀_繁花斗士急流鱼_伪装鲨鲨独角鱼-澄晶果粒饵-战斗
3.稻妻-垂钓点-雷鸣仙（这个根本就没做，太逆天了）