### PR TITLE
地图追踪：禽肉【新增】地图追踪：骗骗花【修复】

### DIFF
--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,5 @@
 {
-  "time": "20250307095247",
+  "time": "20250307134614",
   "url": "https://github.com/babalae/bettergi-scripts-list/archive/refs/heads/main.zip",
   "file": "repo.json",
   "indexes": [

--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,5 @@
 {
-  "time": "20250307134614",
+  "time": "20250307134705",
   "url": "https://github.com/babalae/bettergi-scripts-list/archive/refs/heads/main.zip",
   "file": "repo.json",
   "indexes": [
@@ -20368,6 +20368,78 @@
               "description": "漂浮零",
               "tags": [
                 "漂浮灵"
+              ]
+            }
+          ]
+        },
+        {
+          "name": "禽肉",
+          "type": "directory",
+          "children": [
+            {
+              "name": "璃月-禽肉-珉林华光林西南-2个.json",
+              "type": "file",
+              "hash": "477a0807dbd2f371c77108ca3761abddff259b07",
+              "version": "477a080",
+              "author": "提瓦特钓鱼玳师",
+              "description": "",
+              "tags": [
+                "禽肉"
+              ]
+            },
+            {
+              "name": "璃月-禽肉-琼玑野明蕴镇西南-2个.json",
+              "type": "file",
+              "hash": "f004b667bff179d5e0ce193c8250d6c913721979",
+              "version": "f004b66",
+              "author": "提瓦特钓鱼玳师",
+              "description": "",
+              "tags": [
+                "禽肉"
+              ]
+            },
+            {
+              "name": "璃月-禽肉-琼玑野瑶光滩北-4个.json",
+              "type": "file",
+              "hash": "2954d07e4a766cdc80734b81d3581befd734bfb0",
+              "version": "2954d07",
+              "author": "提瓦特钓鱼玳师",
+              "description": "",
+              "tags": [
+                "禽肉"
+              ]
+            },
+            {
+              "name": "璃月-禽肉-璃月港舔狗桥-5个.json",
+              "type": "file",
+              "hash": "1e4114d5482721f54df3b70ae186a367530c44c2",
+              "version": "1e4114d",
+              "author": "提瓦特钓鱼玳师",
+              "description": "",
+              "tags": [
+                "禽肉"
+              ]
+            },
+            {
+              "name": "蒙德-禽肉-风起地-3个.json",
+              "type": "file",
+              "hash": "73edc9875315555af343412f9c23db16f52b56b9",
+              "version": "73edc98",
+              "author": "提瓦特钓鱼玳师",
+              "description": "",
+              "tags": [
+                "禽肉"
+              ]
+            },
+            {
+              "name": "蒙德-禽肉-风起地东南-11个.json",
+              "type": "file",
+              "hash": "1487a1a0456ee70887c5b1dcd88ae9fe2a82884c",
+              "version": "1487a1a",
+              "author": "提瓦特钓鱼玳师",
+              "description": "",
+              "tags": [
+                "禽肉"
               ]
             }
           ]

--- a/repo.json
+++ b/repo.json
@@ -1,5 +1,5 @@
 {
-  "time": "20250307134705",
+  "time": "20250307143414",
   "url": "https://github.com/babalae/bettergi-scripts-list/archive/refs/heads/main.zip",
   "file": "repo.json",
   "indexes": [
@@ -18997,8 +18997,8 @@
             {
               "name": "璃月-骗骗花-云来海天衡山北方洞内-2个.json",
               "type": "file",
-              "hash": "3fdb6028f7a7153818d1fe9805dfadf6b7fc7189",
-              "version": "3fdb602",
+              "hash": "b03cfef8e3dd4a2ef71d355bdaacd097d7f219b2",
+              "version": "b03cfef",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n璃月-云来海天衡山北方洞内",
               "tags": [
@@ -19019,8 +19019,8 @@
             {
               "name": "璃月-骗骗花-云来海孤云阁西北-1个.json",
               "type": "file",
-              "hash": "8afb57dcc9e974c0284314bb3a0568d2af01008f",
-              "version": "8afb57d",
+              "hash": "d44c5ac895fdb00481d63758a3d664a6ade2092b",
+              "version": "d44c5ac",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-云来海孤云阁西北",
               "tags": [
@@ -19030,8 +19030,8 @@
             {
               "name": "璃月-骗骗花-层岩巨渊巨渊之口东北-3个.json",
               "type": "file",
-              "hash": "58842d434e094448e97a370a376cd28886e1e741",
-              "version": "58842d4",
+              "hash": "125b8b5bed3ece00514d7506fe43abe2a1c9643d",
+              "version": "125b8b5",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n璃月-层岩巨渊巨渊之口东北",
               "tags": [
@@ -19041,8 +19041,8 @@
             {
               "name": "璃月-骗骗花-层岩巨渊巨渊之口东南-6个.json",
               "type": "file",
-              "hash": "dd081f55cb108350c7a8674f8d7c9356dd77380a",
-              "version": "dd081f5",
+              "hash": "e9c60981999a73c2f6bded540ba6291ae455a401",
+              "version": "e9c6098",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-6个\n璃月-层岩巨渊巨渊之口东南",
               "tags": [
@@ -19052,8 +19052,8 @@
             {
               "name": "璃月-骗骗花-珉林南天门西南采樵谷西北-5个.json",
               "type": "file",
-              "hash": "0669867ce9320055b4f58877508281f024a27e59",
-              "version": "0669867",
+              "hash": "8a3f998e82933f5cbe039ab2f58dbec038c35365",
+              "version": "8a3f998",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-5个\n璃月-珉林南天门西南采樵谷西北",
               "tags": [
@@ -19063,8 +19063,8 @@
             {
               "name": "璃月-骗骗花-珉林天遒谷-4个.json",
               "type": "file",
-              "hash": "604a738f709b68d3293f0963b50c459ce8c62527",
-              "version": "604a738",
+              "hash": "b8085b7308bad2a43be6ede0e1e5c4dc839e630a",
+              "version": "b8085b7",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-4个\n璃月-珉林天遒谷",
               "tags": [
@@ -19074,8 +19074,8 @@
             {
               "name": "璃月-骗骗花-珉林奥藏山东侧-1个.json",
               "type": "file",
-              "hash": "7223892ae4ea2df4ca54722be19a135e2c2efbab",
-              "version": "7223892",
+              "hash": "53732205e1d4cd479c08ed9f0aa67b3cca0b5fca",
+              "version": "5373220",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林奥藏山东侧",
               "tags": [
@@ -19096,8 +19096,8 @@
             {
               "name": "璃月-骗骗花-珉林奥藏山东方岸边-4个.json",
               "type": "file",
-              "hash": "35b0a544e72fb6e14efcaf68babb98ccd384b1ab",
-              "version": "35b0a54",
+              "hash": "5511ef8c46ac28da7579405167c8e56eae08a04f",
+              "version": "5511ef8",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-4个\n璃月-珉林奥藏山东方岸边",
               "tags": [
@@ -19107,8 +19107,8 @@
             {
               "name": "璃月-骗骗花-珉林奥藏山南方-1个.json",
               "type": "file",
-              "hash": "3c9a0ad37348393cec73f1b6f0d0f27d8817fdde",
-              "version": "3c9a0ad",
+              "hash": "b97f80cf5ea1d595403ced1d22ed56a0ca26e360",
+              "version": "b97f80c",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林奥藏山南方",
               "tags": [
@@ -19118,8 +19118,8 @@
             {
               "name": "璃月-骗骗花-珉林奥藏山西南方-1个.json",
               "type": "file",
-              "hash": "8325c2491deb02a60850e31d3ec241e238636c43",
-              "version": "8325c24",
+              "hash": "4bd5901ba6ef94ef688e15f7a9b95c95861bfa3a",
+              "version": "4bd5901",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林奥藏山西南方",
               "tags": [
@@ -19129,8 +19129,8 @@
             {
               "name": "璃月-骗骗花-珉林庆云顶东南-1个.json",
               "type": "file",
-              "hash": "2df9a1062aea762d961035091986260089a81df7",
-              "version": "2df9a10",
+              "hash": "28cb346a946d8a2c32bdba63f8e7f0b278599874",
+              "version": "28cb346",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林庆云顶东南",
               "tags": [
@@ -19140,8 +19140,8 @@
             {
               "name": "璃月-骗骗花-珉林庆云顶南方-2个.json",
               "type": "file",
-              "hash": "803fa184700430cdd5648abb9c735a794c9f61c6",
-              "version": "803fa18",
+              "hash": "3a81e78ff58715f389b3c633b3e6a96c6660e504",
+              "version": "3a81e78",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n璃月-珉林庆云顶南方",
               "tags": [
@@ -19151,8 +19151,8 @@
             {
               "name": "璃月-骗骗花-珉林庆云顶西南-1个.json",
               "type": "file",
-              "hash": "ce42e90dc50b81460d3dfd1e72e44eb7180b64f8",
-              "version": "ce42e90",
+              "hash": "8bb5d437a37e411a14a4f0537e6df95adac1fe11",
+              "version": "8bb5d43",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林庆云顶西南",
               "tags": [
@@ -19162,8 +19162,8 @@
             {
               "name": "璃月-骗骗花-珉林琥牢山东侧-1个.json",
               "type": "file",
-              "hash": "d74a3f47704f1b02b3c104e5f4e04529cf8efbdd",
-              "version": "d74a3f4",
+              "hash": "273fc32b280d2f36b732c510462045a933a13a80",
+              "version": "273fc32",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林琥牢山东侧",
               "tags": [
@@ -19173,8 +19173,8 @@
             {
               "name": "璃月-骗骗花-珉林绝云间东北-1个.json",
               "type": "file",
-              "hash": "be6b48e86153566839d201159aa5f6f3f00c877e",
-              "version": "be6b48e",
+              "hash": "06061764c0af6ec225a215cd6b6218ae0362c4a1",
+              "version": "0606176",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-珉林绝云间东北",
               "tags": [
@@ -19184,8 +19184,8 @@
             {
               "name": "璃月-骗骗花-珉林绝云间东南-2个.json",
               "type": "file",
-              "hash": "e5961190168204ad3223d9e86bb0634bf6ba2e62",
-              "version": "e596119",
+              "hash": "30c76f1eea3e89d6084ea5bb45a7556188f55d43",
+              "version": "30c76f1",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n璃月-珉林绝云间东南",
               "tags": [
@@ -19195,8 +19195,8 @@
             {
               "name": "璃月-骗骗花-珉林翠玦坡-4个.json",
               "type": "file",
-              "hash": "7235cc0e4dffe4ccafc57351dd2ddf44a984c431",
-              "version": "7235cc0",
+              "hash": "283b4d07e97a1c204b0f620b25780cb7379c4072",
+              "version": "283b4d0",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-4个\n璃月-珉林翠玦坡",
               "tags": [
@@ -19206,8 +19206,8 @@
             {
               "name": "璃月-骗骗花-珉林荻花洲西方岸边-3个.json",
               "type": "file",
-              "hash": "9e3150aaeafdf1081aff2fa83ee0822c764e6694",
-              "version": "9e3150a",
+              "hash": "55ba9fd064e6d37967ee75097e3ce0adc06cb840",
+              "version": "55ba9fd",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n璃月-珉林荻花洲西方岸边",
               "tags": [
@@ -19239,8 +19239,8 @@
             {
               "name": "璃月-骗骗花-琼玑野渌华池东方崖上-3个.json",
               "type": "file",
-              "hash": "10f257ee037d055e73829fe4402eb4c6bb25a036",
-              "version": "10f257e",
+              "hash": "579d80773e626622a9400681e13efece1d968599",
+              "version": "579d807",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n璃月-琼玑野渌华池东方崖上",
               "tags": [
@@ -19250,8 +19250,8 @@
             {
               "name": "璃月-骗骗花-琼玑野渌华池西南方崖上-3个.json",
               "type": "file",
-              "hash": "cb74dfa75e1c86088b1c8155e7f1e55b1c0b20bc",
-              "version": "cb74dfa",
+              "hash": "8686285688d5f106624bfa0a98c78e1002d01bb8",
+              "version": "8686285",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n璃月-琼玑野渌华池西南方崖上",
               "tags": [
@@ -19272,8 +19272,8 @@
             {
               "name": "璃月-骗骗花-琼玑野瑶光滩-3个.json",
               "type": "file",
-              "hash": "f41d751e19cfa6442ebfa9d214c0c9394787a51c",
-              "version": "f41d751",
+              "hash": "20b20ba59b4c0b4a27c8b0748330acb77de3a1f5",
+              "version": "20b20ba",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n璃月-琼玑野瑶光滩",
               "tags": [
@@ -19283,8 +19283,8 @@
             {
               "name": "璃月-骗骗花-璃沙郊灵矩关东方略偏南-1个.json",
               "type": "file",
-              "hash": "2005dceb871b661bbd44147f6f11f8f18cb827e8",
-              "version": "2005dce",
+              "hash": "d1c5b0271d8941766b20ae893ceffc9829ed8b49",
+              "version": "d1c5b02",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-璃沙郊灵矩关东方略偏南",
               "tags": [
@@ -19294,8 +19294,8 @@
             {
               "name": "璃月-骗骗花-碧水原奥藏山东北方传送锚点附近-2个.json",
               "type": "file",
-              "hash": "5d39e019909fd842b665be0a1317a215f7da5f2d",
-              "version": "5d39e01",
+              "hash": "a714a1056c13ecb5bf4af250660c7ddf1a9724a8",
+              "version": "a714a10",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n璃月-碧水原奥藏山东北方传送锚点附近",
               "tags": [
@@ -19316,8 +19316,8 @@
             {
               "name": "璃月-骗骗花-碧水原无妄坡西南岸边-1个.json",
               "type": "file",
-              "hash": "2d9bc100c70a68762d6f8a4b02cbe5ecf9ccac56",
-              "version": "2d9bc10",
+              "hash": "d528703aa6eb434122a0b51eee7fba13c70057f0",
+              "version": "d528703",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-碧水原无妄坡西南岸边",
               "tags": [
@@ -19327,8 +19327,8 @@
             {
               "name": "璃月-骗骗花-碧水原无妄坡西南崖上-1个.json",
               "type": "file",
-              "hash": "3cba344fea06101b748f91873b7e2b15f6185a96",
-              "version": "3cba344",
+              "hash": "cec7a5e3efe0d1897f743b8db5c9ff19fce69dab",
+              "version": "cec7a5e",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-碧水原无妄坡西南崖上",
               "tags": [
@@ -19338,8 +19338,8 @@
             {
               "name": "璃月-骗骗花-碧水原轻策庄西方-1个.json",
               "type": "file",
-              "hash": "56313d1ac1aab356c0fbdd10deed27577ffabed1",
-              "version": "56313d1",
+              "hash": "e84706506eccbc127744252c4a74a817ca5bbbce",
+              "version": "e847065",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n璃月-碧水原轻策庄西方",
               "tags": [
@@ -19393,8 +19393,8 @@
             {
               "name": "稻妻-骗骗花-八酝岛蛇神之首西南-3个.json",
               "type": "file",
-              "hash": "0a167ae316ffbc325306727ca19ea7225b9f90bb",
-              "version": "0a167ae",
+              "hash": "ebf9a5d4542a41f5510386edae9502aff2887afa",
+              "version": "ebf9a5d",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n稻妻-八酝岛蛇神之首西南",
               "tags": [
@@ -19404,8 +19404,8 @@
             {
               "name": "稻妻-骗骗花-海祇岛望泷村东方-1个.json",
               "type": "file",
-              "hash": "b6b5ec5b5df8d76ad22731d9b3aaf5ad2f4609ed",
-              "version": "b6b5ec5",
+              "hash": "438a1f15077c2614a64e990a8e7c910bf54b1169",
+              "version": "438a1f1",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-海祇岛望泷村东方",
               "tags": [
@@ -19415,8 +19415,8 @@
             {
               "name": "稻妻-骗骗花-海祇岛望泷村南方岸边-1个.json",
               "type": "file",
-              "hash": "16a5987789cd7e53554ed3bece6b85e19f167bf2",
-              "version": "16a5987",
+              "hash": "073822cd820b7af0ac808eb4da94a76efa5e850a",
+              "version": "073822c",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-海祇岛望泷村南方岸边",
               "tags": [
@@ -19426,8 +19426,8 @@
             {
               "name": "稻妻-骗骗花-海祇岛望泷村西南方崖上-2个.json",
               "type": "file",
-              "hash": "5fb265b8cfb4508e856b9f44b026945556cc1c8b",
-              "version": "5fb265b",
+              "hash": "53ec52a03da1c36a0fe563609402d0310deb9a84",
+              "version": "53ec52a",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n稻妻-海祇岛望泷村西南方崖上",
               "tags": [
@@ -19437,8 +19437,8 @@
             {
               "name": "稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个.json",
               "type": "file",
-              "hash": "e3a4898a453f9ac15b5f4259d735ed8db9c5f79e",
-              "version": "e3a4898",
+              "hash": "ff0c3428f7a24e9ffdc9dfbd3579f831b38e0ddf",
+              "version": "ff0c342",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-5个\n稻妻-海祇岛珊瑚宫北方略偏西",
               "tags": [
@@ -19448,8 +19448,8 @@
             {
               "name": "稻妻-骗骗花-海祇岛珊瑚宫西-1个.json",
               "type": "file",
-              "hash": "6e22a7213210b8b162274d5d91af096081fc29a6",
-              "version": "6e22a72",
+              "hash": "16824119d386533562976ec680b6049075c29f1e",
+              "version": "1682411",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-海祇岛珊瑚宫西",
               "tags": [
@@ -19459,8 +19459,8 @@
             {
               "name": "稻妻-骗骗花-清籁岛天云峠南方-1个.json",
               "type": "file",
-              "hash": "a11a50821a6e61eee86046a3cca357e6d6ec85ef",
-              "version": "a11a508",
+              "hash": "c2d647d4c95b6fa4d588c3c91e1fb67c9a0cbb0a",
+              "version": "c2d647d",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-清籁岛天云峠南方",
               "tags": [
@@ -19470,8 +19470,8 @@
             {
               "name": "稻妻-骗骗花-清籁岛浅濑神社东南方-4个.json",
               "type": "file",
-              "hash": "49394f98a1bd9175923fef0ddf88a67aa736fb41",
-              "version": "49394f9",
+              "hash": "4c776311c529860e7ded84028182947a8ee63187",
+              "version": "4c77631",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-4个\n稻妻-清籁岛浅濑神社东南方",
               "tags": [
@@ -19481,8 +19481,8 @@
             {
               "name": "稻妻-骗骗花-清籁岛浅濑神社东方-1个.json",
               "type": "file",
-              "hash": "22a430accc9869f82c2499444740348aeea7127e",
-              "version": "22a430a",
+              "hash": "b779b3a77b24d5946501313840f0bb1059ededfb",
+              "version": "b779b3a",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-清籁岛浅濑神社东方",
               "tags": [
@@ -19492,8 +19492,8 @@
             {
               "name": "稻妻-骗骗花-清籁岛越石村东北方-2个.json",
               "type": "file",
-              "hash": "93ab879cb2f7882cb2afa3f4c31ae53f2ec78c5f",
-              "version": "93ab879",
+              "hash": "a2316f525f7e21177317119bb591dafe7d2fd564",
+              "version": "a2316f5",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n稻妻-清籁岛越石村东北方",
               "tags": [
@@ -19503,8 +19503,8 @@
             {
               "name": "稻妻-骗骗花-清籁岛越石村北方-2个.json",
               "type": "file",
-              "hash": "6519638ef109164f6f895d6b6049f9c1c07c9086",
-              "version": "6519638",
+              "hash": "7d1ba597a7f6869529430900ef94b8e694a42eec",
+              "version": "7d1ba59",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n稻妻-清籁岛越石村北方",
               "tags": [
@@ -19514,8 +19514,8 @@
             {
               "name": "稻妻-骗骗花-神无冢踏鞴砂东北岸边-1个.json",
               "type": "file",
-              "hash": "3b890ba3bb91b6b6e78197f7ae764a3672689fe1",
-              "version": "3b890ba",
+              "hash": "515374e8a6a56d3d7f7449c6f8d72026dabf223d",
+              "version": "515374e",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-神无冢踏鞴砂东北岸边",
               "tags": [
@@ -19525,8 +19525,8 @@
             {
               "name": "稻妻-骗骗花-神无冢踏鞴砂东北崖下-3个.json",
               "type": "file",
-              "hash": "a43fc35a68a7dd52a4fd7163c531ccd90548f05c",
-              "version": "a43fc35",
+              "hash": "e332be6803a88ea1a08426d93296571869f854c5",
+              "version": "e332be6",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n稻妻-神无冢踏鞴砂东北崖下",
               "tags": [
@@ -19536,8 +19536,8 @@
             {
               "name": "稻妻-骗骗花-神无冢踏鞴砂西崖上-2个.json",
               "type": "file",
-              "hash": "ac7deb59bb1bda88f3ecf5458b66ba7d04be4394",
-              "version": "ac7deb5",
+              "hash": "84c2315c5c388ca9497f398887d6e28d84b9f119",
+              "version": "84c2315",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n稻妻-神无冢踏鞴砂西崖上",
               "tags": [
@@ -19547,8 +19547,8 @@
             {
               "name": "稻妻-骗骗花-鸣神岛影向山-1个.json",
               "type": "file",
-              "hash": "f1c7096ead12c2d6f2cdeb200d9167e2a5717f56",
-              "version": "f1c7096",
+              "hash": "699045f012a26f5b5c0d5326e3f3004c299ac60b",
+              "version": "699045f",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-鸣神岛影向山",
               "tags": [
@@ -19558,8 +19558,8 @@
             {
               "name": "稻妻-骗骗花-鸣神岛白狐之野-3个.json",
               "type": "file",
-              "hash": "b86e75c5f280acc8368894344e846aeab506b8ad",
-              "version": "b86e75c",
+              "hash": "312b02f7947c7c166ffff17eeb8209f791c559c8",
+              "version": "312b02f",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n稻妻-鸣神岛白狐之野",
               "tags": [
@@ -19569,8 +19569,8 @@
             {
               "name": "稻妻-骗骗花-鸣神岛神里屋敷西北-1个.json",
               "type": "file",
-              "hash": "d61acf35399a01df682499ea467ddf32253c52af",
-              "version": "d61acf3",
+              "hash": "522762b722de5ecf218ab5e861c87762efb11f0a",
+              "version": "522762b",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-鸣神岛神里屋敷西北",
               "tags": [
@@ -19580,8 +19580,8 @@
             {
               "name": "稻妻-骗骗花-鸣神岛绀田村北方-2个.json",
               "type": "file",
-              "hash": "8da40c12a7e01737c2688485a15bc67f7ed6e945",
-              "version": "8da40c1",
+              "hash": "c9e115383f0cf680c91242f025d7fd79f15c4ad7",
+              "version": "c9e1153",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n稻妻-鸣神岛绀田村北方",
               "tags": [
@@ -19613,8 +19613,8 @@
             {
               "name": "稻妻-骗骗花-鹤观惑饲滩西方崖上-1个.json",
               "type": "file",
-              "hash": "06f1868e7608569c17ccc61905bd8cd8fc841d8b",
-              "version": "06f1868",
+              "hash": "dd6c6f34030d37ae5c7b173c2425df0d5a7c041e",
+              "version": "dd6c6f3",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-鹤观惑饲滩西方崖上",
               "tags": [
@@ -19635,8 +19635,8 @@
             {
               "name": "稻妻-骗骗花-鹤观笈名海滨-2个.json",
               "type": "file",
-              "hash": "f129912a69593ed03518d708aba6a77a54a86b1a",
-              "version": "f129912",
+              "hash": "93f6d14973d985755b45aa808b96a65a59f6650f",
+              "version": "93f6d14",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n稻妻-鹤观笈名海滨",
               "tags": [
@@ -19646,8 +19646,8 @@
             {
               "name": "稻妻-骗骗花-鹤观茂知祭场东北-1个.json",
               "type": "file",
-              "hash": "73150aa640e1a2b07c595ac1b33fb8a27284bb4c",
-              "version": "73150aa",
+              "hash": "dcac17c8bc75e9aede3221d8dbb215817e6a1caf",
+              "version": "dcac17c",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-鹤观茂知祭场东北",
               "tags": [
@@ -19657,8 +19657,8 @@
             {
               "name": "稻妻-骗骗花-鹤观菅名山东北侧-1个.json",
               "type": "file",
-              "hash": "06ee9710d04bb5a1fe80fa0efb715ace63efe6b4",
-              "version": "06ee971",
+              "hash": "78f65e30518f1e59507b076c4a67fa1df64998d9",
+              "version": "78f65e3",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-1个\n稻妻-鹤观菅名山东北侧",
               "tags": [
@@ -19668,8 +19668,8 @@
             {
               "name": "蒙德-骗骗花-坠星山谷千风神殿南略偏西-3个.json",
               "type": "file",
-              "hash": "95a9b48d8e41c1c981fa5d794f5e80d7b26ec685",
-              "version": "95a9b48",
+              "hash": "d6a9d83e103d7663a11fe31651dbfa491da9a557",
+              "version": "d6a9d83",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n蒙德-坠星山谷千风神殿南略偏西",
               "tags": [
@@ -19679,8 +19679,8 @@
             {
               "name": "蒙德-骗骗花-坠星山谷望风山地-2个.json",
               "type": "file",
-              "hash": "f51090955c3f4645d1ba322fbfba98aef7ea1327",
-              "version": "f510909",
+              "hash": "9b1d67e4540400c14e3468560f6f2d6241c0e653",
+              "version": "9b1d67e",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n蒙德-坠星山谷望风山地",
               "tags": [
@@ -19690,8 +19690,8 @@
             {
               "name": "蒙德-骗骗花-坠星山谷望风角和摘星崖-2个.json",
               "type": "file",
-              "hash": "dcda57e1f641c6cc33625ce03f833fc8b18d7e35",
-              "version": "dcda57e",
+              "hash": "f088b8248234d354781c11c16403f4bfe5d6f040",
+              "version": "f088b82",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n蒙德-坠星山谷望风角和摘星崖",
               "tags": [
@@ -19734,10 +19734,10 @@
             {
               "name": "蒙德-骗骗花-苍风高地晨曦酒庄湖中和湖边崖上-2个.json",
               "type": "file",
-              "hash": "e0bf6b4f68ebc6fd8c1a7276a9cc2eb76bd4cac4",
-              "version": "e0bf6b4",
+              "hash": "fc6af651c6b27f4ce1e25770729db2452d658383",
+              "version": "fc6af65",
               "author": "提瓦特钓鱼玳师",
-              "description": "骗骗花-1个\n蒙德-龙脊雪山",
+              "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄湖中和湖边崖上",
               "tags": [
                 "骗骗花"
               ]
@@ -19745,8 +19745,8 @@
             {
               "name": "蒙德-骗骗花-苍风高地晨曦酒庄西南崖上-2个.json",
               "type": "file",
-              "hash": "b24b4f924c2653b0cabe811742eb38e7e8c4a92e",
-              "version": "b24b4f9",
+              "hash": "84b3202df06474ad3bed3f67af8d3a35e77cbee9",
+              "version": "84b3202",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄西南崖上",
               "tags": [
@@ -19756,8 +19756,8 @@
             {
               "name": "蒙德-骗骗花-苍风高地晨曦酒庄西南石门北-2个.json",
               "type": "file",
-              "hash": "1ad82b17e7c661cd721f819cf957d765f0a566d5",
-              "version": "1ad82b1",
+              "hash": "515fcdcebc16b34389a1c5de24f18513e1e36a79",
+              "version": "515fcdc",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄西南石门北",
               "tags": [
@@ -19800,8 +19800,8 @@
             {
               "name": "蒙德-骗骗花-风啸山坡达达乌帕谷西方略偏北-2个.json",
               "type": "file",
-              "hash": "39ebeda42e822696712e6d5cb84112629c13d40f",
-              "version": "39ebeda",
+              "hash": "e136ffc90563eafa7267bfbd6a883529e70adb95",
+              "version": "e136ffc",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-2个\n蒙德-风啸山坡达达乌帕谷西方略偏北",
               "tags": [
@@ -19811,8 +19811,8 @@
             {
               "name": "蒙德-骗骗花-风啸山坡风起地西南方-3个.json",
               "type": "file",
-              "hash": "3bf630a2865b05d749fa38df9f7dbb9fb42a1874",
-              "version": "3bf630a",
+              "hash": "bb81160bec8784f623009e8dc7890653961a48fa",
+              "version": "bb81160",
               "author": "提瓦特钓鱼玳师",
               "description": "骗骗花-3个\n蒙德-风啸山坡风起地西南方",
               "tags": [

--- a/repo/pathing/禽肉/璃月-禽肉-珉林华光林西南-2个.json
+++ b/repo/pathing/禽肉/璃月-禽肉-珉林华光林西南-2个.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "璃月-禽肉-珉林华光林西南-2个",
+    "type": "collect",
+    "author": "提瓦特钓鱼玳师",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 1604.4638671875,
+      "y": 1039.69775390625,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": 1608.359375,
+      "y": 1038.4423828125,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": 1803.63671875,
+      "y": 887.34033203125,
+      "action": "combat_script",
+      "move_mode": "fly",
+      "action_params": "keypress(space),wait(3),attack(0.1)",
+      "type": "target"
+    },
+    {
+      "id": 4,
+      "x": 1803.63671875,
+      "y": 887.34033203125,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    }
+  ]
+}

--- a/repo/pathing/禽肉/璃月-禽肉-琼玑野明蕴镇西南-2个.json
+++ b/repo/pathing/禽肉/璃月-禽肉-琼玑野明蕴镇西南-2个.json
@@ -1,0 +1,49 @@
+{
+  "info": {
+    "name": "璃月-禽肉-琼玑野明蕴镇西南-2个",
+    "type": "collect",
+    "author": "提瓦特钓鱼玳师",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": -255.0830078125,
+      "y": 630.08740234375,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -252.2666015625,
+      "y": 621.22314453125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -151.7197265625,
+      "y": 595.47119140625,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": "",
+      "locked": false
+    },
+    {
+      "id": 4,
+      "x": -151.7197265625,
+      "y": 595.47119140625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "pick_around",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/禽肉/璃月-禽肉-琼玑野瑶光滩北-4个.json
+++ b/repo/pathing/禽肉/璃月-禽肉-琼玑野瑶光滩北-4个.json
@@ -1,0 +1,75 @@
+{
+  "info": {
+    "name": "璃月-禽肉-琼玑野瑶光滩北-4个",
+    "type": "collect",
+    "author": "提瓦特钓鱼玳师",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": -255.0322265625,
+      "y": 630.05224609375,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -261.8974609375,
+      "y": 628.083984375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -264.154296875,
+      "y": 619.02099609375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": -282.6435546875,
+      "y": 573.30126953125,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "combat_script",
+      "action_params": "keypress(space),wait(2),attack(0.1)"
+    },
+    {
+      "id": 5,
+      "x": -282.6748046875,
+      "y": 573.28564453125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "pick_around",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": -255.3623046875,
+      "y": 500.31298828125,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "x": -255.326171875,
+      "y": 500.3017578125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "pick_around",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/禽肉/璃月-禽肉-璃月港舔狗桥-5个.json
+++ b/repo/pathing/禽肉/璃月-禽肉-璃月港舔狗桥-5个.json
@@ -1,0 +1,84 @@
+{
+  "info": {
+    "name": "璃月-禽肉-璃月港舔狗桥-5个",
+    "type": "collect",
+    "author": "提瓦特钓鱼玳师",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 267.9375,
+      "y": -665.15234375,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": 261.947265625,
+      "y": -660.7705078125,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": 270.125,
+      "y": -641.65625,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": 295.248046875,
+      "y": -620.65380859375,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 5,
+      "x": 291.09765625,
+      "y": -616.4267578125,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 6,
+      "x": 285.900390625,
+      "y": -619.94775390625,
+      "action": "",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 7,
+      "x": 276.85546875,
+      "y": -605.8193359375,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 8,
+      "x": 276.85546875,
+      "y": -605.8193359375,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    }
+  ]
+}

--- a/repo/pathing/禽肉/蒙德-禽肉-风起地-3个.json
+++ b/repo/pathing/禽肉/蒙德-禽肉-风起地-3个.json
@@ -1,0 +1,94 @@
+{
+  "info": {
+    "name": "蒙德-禽肉-风起地-3个",
+    "type": "collect",
+    "author": "提瓦特钓鱼玳师",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": -1266.4365234375,
+      "y": 1933.716796875,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -1271.3154296875,
+      "y": 1924.52734375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -1266.9501953125,
+      "y": 1893.58544921875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": -1263.4951171875,
+      "y": 1888.15625,
+      "type": "target",
+      "move_mode": "climb",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": -1263.05078125,
+      "y": 1889.84619140625,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": -1261.1962890625,
+      "y": 1895.8837890625,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 7,
+      "x": -1262.5205078125,
+      "y": 1904.91748046875,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 8,
+      "x": -1271.8134765625,
+      "y": 1973.873046875,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": "",
+      "locked": false
+    },
+    {
+      "id": 9,
+      "x": -1271.8134765625,
+      "y": 1973.873046875,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "pick_around",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/禽肉/蒙德-禽肉-风起地东南-11个.json
+++ b/repo/pathing/禽肉/蒙德-禽肉-风起地东南-11个.json
@@ -1,0 +1,192 @@
+{
+  "info": {
+    "name": "蒙德-禽肉-风起地东南-11个",
+    "type": "collect",
+    "author": "提瓦特钓鱼玳师",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.35.1"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -1427.7998046875,
+      "y": 1661.54052734375,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": -1433.423828125,
+      "y": 1650.64892578125,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 3,
+      "x": -1441.4716796875,
+      "y": 1646.1181640625,
+      "action": "",
+      "move_mode": "climb",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 4,
+      "x": -1455.845703125,
+      "y": 1671.85107421875,
+      "action": "",
+      "move_mode": "run",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 5,
+      "x": -1434.494140625,
+      "y": 1685.6611328125,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 6,
+      "x": -1434.494140625,
+      "y": 1685.6611328125,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 7,
+      "x": -1408.705078125,
+      "y": 1741.19189453125,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 8,
+      "x": -1408.705078125,
+      "y": 1741.19189453125,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 9,
+      "x": -1394.9345703125,
+      "y": 1732.388671875,
+      "action": "",
+      "move_mode": "run",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 10,
+      "x": -1383.53515625,
+      "y": 1726.7109375,
+      "action": "",
+      "move_mode": "run",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 11,
+      "x": -1371.033203125,
+      "y": 1728.06982421875,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "wait(0.5),keypress(space),wait(0.5),keypress(space),wait(4)",
+      "type": "target"
+    },
+    {
+      "id": 12,
+      "x": -1339.7978515625,
+      "y": 1727.9658203125,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 13,
+      "x": -1339.7978515625,
+      "y": 1727.9658203125,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 14,
+      "x": -1350.1748046875,
+      "y": 1741.8935546875,
+      "action": "",
+      "move_mode": "run",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 15,
+      "x": -1371.38671875,
+      "y": 1727.927734375,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "wait(0.5),keypress(space),wait(0.5),keypress(space),wait(6)",
+      "type": "target"
+    },
+    {
+      "id": 16,
+      "x": -1359.09765625,
+      "y": 1672.12890625,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 17,
+      "x": -1359.09765625,
+      "y": 1672.12890625,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 18,
+      "x": -1371.5185546875,
+      "y": 1728.3857421875,
+      "action": "combat_script",
+      "move_mode": "fly",
+      "action_params": "wait(0.5),keypress(f)",
+      "type": "target"
+    },
+    {
+      "id": 19,
+      "x": -1408.49609375,
+      "y": 1808.78466796875,
+      "action": "stop_flying",
+      "move_mode": "fly",
+      "action_params": "",
+      "type": "target"
+    },
+    {
+      "id": 20,
+      "x": -1408.49609375,
+      "y": 1808.78466796875,
+      "action": "pick_around",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "target"
+    }
+  ]
+}

--- a/repo/pathing/骗骗花/璃月-骗骗花-云来海天衡山北方洞内-2个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-云来海天衡山北方洞内-2个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-云来海天衡山北方洞内-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n璃月-云来海天衡山北方洞内",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -33,7 +33,7 @@
             "action": "combat_script",
             "move_mode": "fly",
             "action_params": "keypress(space),wait(3),keypress(space)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 4,

--- a/repo/pathing/骗骗花/璃月-骗骗花-云来海孤云阁西北-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-云来海孤云阁西北-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-云来海孤云阁西北-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-云来海孤云阁西北",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -544.75,
             "y": -146.12,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-层岩巨渊巨渊之口东北-3个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-层岩巨渊巨渊之口东北-3个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-层岩巨渊巨渊之口东北-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n璃月-层岩巨渊巨渊之口东北",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": 1639.46,
             "y": -675.63,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-层岩巨渊巨渊之口东南-6个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-层岩巨渊巨渊之口东南-6个.json
@@ -24,7 +24,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "keypress(space),wait(0.8),keypress(space)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 3,
@@ -33,7 +33,7 @@
             "action": "combat_script",
             "move_mode": "fly",
             "action_params": "attack(0.1),wait(0.2),keypress(f),wait(0.2),keypress(f),wait(0.2),keypress(f),wait(0.2),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 4,
@@ -60,7 +60,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "keypress(space),wait(0.8),keypress(space)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 7,
@@ -186,7 +186,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path",
+            "type": "target",
             "locked": false
         },
         {
@@ -205,7 +205,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path",
+            "type": "target",
             "locked": false
         },
         {
@@ -224,7 +224,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 25,
@@ -260,7 +260,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 29,

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林南天门西南采樵谷西北-5个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林南天门西南采樵谷西北-5个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林南天门西南采樵谷西北-5个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-5个\n璃月-珉林南天门西南采樵谷西北",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -75,7 +75,7 @@
             "id": 8,
             "x": 1848.2,
             "y": -187.74,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -157,7 +157,7 @@
             "id": 17,
             "x": 2019.79,
             "y": -41.33,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -230,7 +230,7 @@
             "id": 25,
             "x": 1928.02,
             "y": 187.65,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林天遒谷-4个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林天遒谷-4个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林天遒谷-4个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-4个\n璃月-珉林天遒谷",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -30,7 +30,7 @@
             "id": 3,
             "x": 1295.57,
             "y": 217.21,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)"

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山东侧-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山东侧-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林奥藏山东侧-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林奥藏山东侧",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -30,7 +30,7 @@
             "id": 3,
             "x": 1404.19,
             "y": 1045.92,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山东方岸边-4个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山东方岸边-4个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林奥藏山东方岸边-4个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-4个\n璃月-珉林奥藏山东方岸边",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -57,7 +57,7 @@
             "id": 6,
             "x": 1185.75,
             "y": 1362.69,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -85,7 +85,7 @@
             "id": 9,
             "x": 1035.26,
             "y": 1312.45,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -113,7 +113,7 @@
             "id": 12,
             "x": 909.09,
             "y": 1245.88,
-            "type": "path",
+            "type": "target",
             "move_mode": "run",
             "action": "combat_script",
             "locked": false

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山南方-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山南方-1个.json
@@ -24,7 +24,7 @@
             "action": "combat_script",
             "move_mode": "fly",
             "action_params": "keypress(space),wait(3),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 3,

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山西南方-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林奥藏山西南方-1个.json
@@ -24,7 +24,7 @@
             "action": "combat_script",
             "move_mode": "fly",
             "action_params": "keypress(space),wait(3),attack(0.1),wait(2)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 3,

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林庆云顶东南-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林庆云顶东南-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林庆云顶东南-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林庆云顶东南",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": 1365.25,
             "y": 780.33,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "keypress(space),wait(5),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林庆云顶南方-2个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林庆云顶南方-2个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林庆云顶南方-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n璃月-珉林庆云顶南方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": 1418.34,
             "y": 624.24,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "keypress(space),wait(2),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -76,7 +76,7 @@
             "id": 8,
             "x": 1525.62,
             "y": 555.74,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林庆云顶西南-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林庆云顶西南-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林庆云顶西南-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林庆云顶西南",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": 1583.46,
             "y": 676.74,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "keypress(space),wait(4.5),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林琥牢山东侧-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林琥牢山东侧-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林琥牢山东侧-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林琥牢山东侧",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": 1809.59,
             "y": 729.21,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林绝云间东北-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林绝云间东北-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林绝云间东北-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-珉林绝云间东北",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": 1076.78,
             "y": 985.62,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林绝云间东南-2个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林绝云间东南-2个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林绝云间东南-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n璃月-珉林绝云间东南",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -48,7 +48,7 @@
             "id": 5,
             "x": 1158.56,
             "y": 541.61,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -85,7 +85,7 @@
             "id": 9,
             "x": 1019.27,
             "y": 544.02,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林翠玦坡-4个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林翠玦坡-4个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林翠玦坡-4个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-4个\n璃月-珉林翠玦坡",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -129,7 +129,7 @@
             "id": 14,
             "x": 760.52,
             "y": 595.34,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -166,7 +166,7 @@
             "id": 18,
             "x": 633.48,
             "y": 654.98,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-珉林荻花洲西方岸边-3个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-珉林荻花洲西方岸边-3个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-珉林荻花洲西方岸边-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n璃月-珉林荻花洲西方岸边",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -31,7 +31,7 @@
             "id": 3,
             "x": 752.96,
             "y": 1064.3,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -68,7 +68,7 @@
             "id": 7,
             "x": 715.39,
             "y": 990.1,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-琼玑野渌华池东方崖上-3个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-琼玑野渌华池东方崖上-3个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-琼玑野渌华池东方崖上-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n璃月-琼玑野渌华池东方崖上",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": 144.33,
             "y": 148.33,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-琼玑野渌华池西南方崖上-3个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-琼玑野渌华池西南方崖上-3个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-琼玑野渌华池西南方崖上-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n璃月-琼玑野渌华池西南方崖上",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -120,7 +120,7 @@
             "id": 13,
             "x": 761.76,
             "y": 7.08,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-琼玑野瑶光滩-3个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-琼玑野瑶光滩-3个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-琼玑野瑶光滩-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n璃月-琼玑野瑶光滩",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -30,7 +30,7 @@
             "id": 3,
             "x": -291.12,
             "y": 610.58,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-璃沙郊灵矩关东方略偏南-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-璃沙郊灵矩关东方略偏南-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-璃沙郊灵矩关东方略偏南-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-璃沙郊灵矩关东方略偏南",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -33,7 +33,7 @@
             "action": "combat_script",
             "move_mode": "fly",
             "action_params": "keypress(space),wait(2),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 4,

--- a/repo/pathing/骗骗花/璃月-骗骗花-碧水原奥藏山东北方传送锚点附近-2个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-碧水原奥藏山东北方传送锚点附近-2个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-碧水原奥藏山东北方传送锚点附近-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n璃月-碧水原奥藏山东北方传送锚点附近",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": 1270.08,
             "y": 1563.87,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -58,7 +58,7 @@
             "id": 6,
             "x": 1166.84,
             "y": 1439.26,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-碧水原无妄坡西南岸边-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-碧水原无妄坡西南岸边-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-碧水原无妄坡西南岸边-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-碧水原无妄坡西南岸边",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -24,7 +24,7 @@
             "action": "combat_script",
             "move_mode": "fly",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 3,

--- a/repo/pathing/骗骗花/璃月-骗骗花-碧水原无妄坡西南崖上-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-碧水原无妄坡西南崖上-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-碧水原无妄坡西南崖上-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-碧水原无妄坡西南崖上",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": 476.54,
             "y": 1515.46,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/璃月-骗骗花-碧水原轻策庄西方-1个.json
+++ b/repo/pathing/骗骗花/璃月-骗骗花-碧水原轻策庄西方-1个.json
@@ -3,9 +3,9 @@
         "name": "璃月-骗骗花-碧水原轻策庄西方-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n璃月-碧水原轻策庄西方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": 853.28,
             "y": 1754.66,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-八酝岛蛇神之首西南-3个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-八酝岛蛇神之首西南-3个.json
@@ -42,7 +42,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 5,
@@ -60,7 +60,7 @@
             "action": "combat_script",
             "move_mode": "run",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path",
+            "type": "target",
             "locked": false
         },
         {
@@ -79,7 +79,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 9,

--- a/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛望泷村东方-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛望泷村东方-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-海祇岛望泷村东方-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-海祇岛望泷村东方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -1048.31,
             "y": -3982.4,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛望泷村南方岸边-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛望泷村南方岸边-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-海祇岛望泷村南方岸边-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-海祇岛望泷村南方岸边",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -813.65,
             "y": -4111.52,
-            "type": "path",
+            "type": "target",
             "move_mode": "run",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛望泷村西南方崖上-2个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛望泷村西南方崖上-2个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-海祇岛望泷村西南方崖上-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n稻妻-海祇岛望泷村西南方崖上",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -48,7 +48,7 @@
             "id": 5,
             "x": -662.41,
             "y": -4040.4,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛珊瑚宫北方略偏西-5个.json
@@ -51,7 +51,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 6,
@@ -78,7 +78,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path",
+            "type": "target",
             "locked": false
         },
         {
@@ -97,7 +97,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path",
+            "type": "target",
             "locked": false
         },
         {
@@ -116,7 +116,7 @@
             "action": "combat_script",
             "move_mode": "walk",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-            "type": "path"
+            "type": "target"
         },
         {
             "id": 13,

--- a/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛珊瑚宫西-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-海祇岛珊瑚宫西-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-海祇岛珊瑚宫西-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-海祇岛珊瑚宫西",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -48,7 +48,7 @@
             "id": 5,
             "x": -680.67,
             "y": -3768.89,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛天云峠南方-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛天云峠南方-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-清籁岛天云峠南方-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-清籁岛天云峠南方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -4287.33,
             "y": -5075.24,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "keypress(space),wait(7),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛浅濑神社东南方-4个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛浅濑神社东南方-4个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-清籁岛浅濑神社东南方-4个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-4个\n稻妻-清籁岛浅濑神社东南方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -40,7 +40,7 @@
             "id": 4,
             "x": -3720.66,
             "y": -4630.69,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -86,7 +86,7 @@
             "id": 9,
             "x": -3800.48,
             "y": -4536.62,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛浅濑神社东方-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛浅濑神社东方-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-清籁岛浅濑神社东方-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-清籁岛浅濑神社东方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -3933.63,
             "y": -4776.2,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "keypress(space),wait(7),attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛越石村东北方-2个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛越石村东北方-2个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-清籁岛越石村东北方-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n稻妻-清籁岛越石村东北方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -4101.47,
             "y": -4255.78,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -67,7 +67,7 @@
             "id": 7,
             "x": -4078.47,
             "y": -4323.53,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛越石村北方-2个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-清籁岛越石村北方-2个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-清籁岛越石村北方-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n稻妻-清籁岛越石村北方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -3899.75,
             "y": -4257.95,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -85,7 +85,7 @@
             "id": 9,
             "x": -3814.93,
             "y": -4167.96,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-神无冢踏鞴砂东北岸边-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-神无冢踏鞴砂东北岸边-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-神无冢踏鞴砂东北岸边-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-神无冢踏鞴砂东北岸边",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -30,7 +30,7 @@
             "id": 3,
             "x": -3358.22,
             "y": -3474.6,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-神无冢踏鞴砂东北崖下-3个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-神无冢踏鞴砂东北崖下-3个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-神无冢踏鞴砂东北崖下-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n稻妻-神无冢踏鞴砂东北崖下",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -3246.6,
             "y": -3621.94,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f)"
@@ -30,7 +30,7 @@
             "id": 3,
             "x": -3233.87,
             "y": -3617.19,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)"
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -3230.96,
             "y": -3633.95,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-神无冢踏鞴砂西崖上-2个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-神无冢踏鞴砂西崖上-2个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-神无冢踏鞴砂西崖上-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n稻妻-神无冢踏鞴砂西崖上",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -3102.22,
             "y": -3703.83,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛影向山-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛影向山-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鸣神岛影向山-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-鸣神岛影向山",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -4464.15,
             "y": -2618.46,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "attack(0.1),wait(2),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛白狐之野-3个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛白狐之野-3个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鸣神岛白狐之野-3个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-3个\n稻妻-鸣神岛白狐之野",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -4213.13,
             "y": -2932.01,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)"
@@ -48,7 +48,7 @@
             "id": 5,
             "x": -4216.17,
             "y": -2929.93,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)"
@@ -57,7 +57,7 @@
             "id": 6,
             "x": -4213.6,
             "y": -2928.41,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛神里屋敷西北-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛神里屋敷西北-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鸣神岛神里屋敷西北-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-鸣神岛神里屋敷西北",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -39,7 +39,7 @@
             "id": 4,
             "x": -4574.86,
             "y": -2498.64,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛绀田村北方-2个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鸣神岛绀田村北方-2个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鸣神岛绀田村北方-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n稻妻-鸣神岛绀田村北方",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -4161.26,
             "y": -2663.79,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
@@ -59,7 +59,7 @@
             "id": 6,
             "x": -4156.41,
             "y": -2547.41,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鹤观惑饲滩西方崖上-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鹤观惑饲滩西方崖上-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鹤观惑饲滩西方崖上-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-鹤观惑饲滩西方崖上",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -2591.15,
             "y": -6496.81,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鹤观笈名海滨-2个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鹤观笈名海滨-2个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鹤观笈名海滨-2个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-2个\n稻妻-鹤观笈名海滨",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -2544.25,
             "y": -6117.49,
-            "type": "path",
+            "type": "target",
             "move_mode": "fly",
             "action": "combat_script",
             "action_params": "keypress(space),wait(2),attack(0.1),wait(2),keypress(f),wait(0.1),keypress(f)"
@@ -57,7 +57,7 @@
             "id": 6,
             "x": -2718.68,
             "y": -6084.74,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鹤观茂知祭场东北-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鹤观茂知祭场东北-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鹤观茂知祭场东北-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-鹤观茂知祭场东北",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -21,7 +21,7 @@
             "id": 2,
             "x": -3091.47,
             "y": -6245.3,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/稻妻-骗骗花-鹤观菅名山东北侧-1个.json
+++ b/repo/pathing/骗骗花/稻妻-骗骗花-鹤观菅名山东北侧-1个.json
@@ -3,9 +3,9 @@
         "name": "稻妻-骗骗花-鹤观菅名山东北侧-1个",
         "type": "collect",
         "author": "提瓦特钓鱼玳师",
-        "version": "1.0",
+        "version": "1.1",
         "description": "骗骗花-1个\n稻妻-鹤观菅名山东北侧",
-        "bgiVersion": "0.39.1"
+        "bgiVersion": "0.42.0"
     },
     "positions": [
         {
@@ -57,7 +57,7 @@
             "id": 6,
             "x": -2749.44,
             "y": -6237.5,
-            "type": "path",
+            "type": "target",
             "move_mode": "walk",
             "action": "combat_script",
             "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)",

--- a/repo/pathing/骗骗花/蒙德-骗骗花-坠星山谷千风神殿南略偏西-3个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-坠星山谷千风神殿南略偏西-3个.json
@@ -1,120 +1,120 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-坠星山谷千风神殿南略偏西-3个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-3个\n蒙德-坠星山谷千风神殿南略偏西",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -1526.5,
-      "y": 1967.2636533385394,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-坠星山谷千风神殿南略偏西-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-3个\n蒙德-坠星山谷千风神殿南略偏西",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -1554,
-      "y": 2013.7875709005802,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 3,
-      "x": -1575.5,
-      "y": 2054.8086595036693,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 4,
-      "x": -1583.0010179404817,
-      "y": 2048.249099876697,
-      "action": "combat_script",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path",
-      "move_mode": "walk"
-    },
-    {
-      "id": 5,
-      "x": -1582.74869121938,
-      "y": 2042.9980711643511,
-      "action": "combat_script",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path",
-      "move_mode": "walk"
-    },
-    {
-      "id": 6,
-      "x": -1587,
-      "y": 2045.3037731200275,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path"
-    },
-    {
-      "id": 7,
-      "x": -1587,
-      "y": 2045.3037731200275,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 8,
-      "x": -1596.5,
-      "y": 2079.8924995598572,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 9,
-      "x": -1629.5,
-      "y": 2097.4015007928847,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 10,
-      "x": -1634,
-      "y": 2066.3855557515235,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 11,
-      "x": -1623.5,
-      "y": 2003.853408490715,
-      "action": "stop_flying",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 12,
-      "x": -1623.5,
-      "y": 2003.853408490715,
-      "action": "fight",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -1526.5,
+            "y": 1967.26,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -1554,
+            "y": 2013.79,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": -1575.5,
+            "y": 2054.81,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 4,
+            "x": -1583.0,
+            "y": 2048.25,
+            "action": "combat_script",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target",
+            "move_mode": "walk"
+        },
+        {
+            "id": 5,
+            "x": -1582.75,
+            "y": 2043.0,
+            "action": "combat_script",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target",
+            "move_mode": "walk"
+        },
+        {
+            "id": 6,
+            "x": -1587,
+            "y": 2045.3,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target"
+        },
+        {
+            "id": 7,
+            "x": -1587,
+            "y": 2045.3,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 8,
+            "x": -1596.5,
+            "y": 2079.89,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 9,
+            "x": -1629.5,
+            "y": 2097.4,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 10,
+            "x": -1634,
+            "y": 2066.39,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 11,
+            "x": -1623.5,
+            "y": 2003.85,
+            "action": "stop_flying",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 12,
+            "x": -1623.5,
+            "y": 2003.85,
+            "action": "fight",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-坠星山谷望风山地-2个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-坠星山谷望风山地-2个.json
@@ -1,116 +1,116 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-坠星山谷望风山地-2个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-2个\n蒙德-坠星山谷望风山地",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -1273.4699999999993,
-      "y": 2722.3199999999997,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-坠星山谷望风山地-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-2个\n蒙德-坠星山谷望风山地",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -1260.4953465577946,
-      "y": 2805.999742821914,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 3,
-      "x": -1191,
-      "y": 2805.4742821913533,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": ",wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 4,
-      "x": -1191,
-      "y": 2805.4742821913533,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": ",wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 5,
-      "x": -1191,
-      "y": 2805.4742821913533,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": ",wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 6,
-      "x": -1193.5013814906542,
-      "y": 2808.1268645411274,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": ",wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 7,
-      "x": -1188.9988366394482,
-      "y": 2808.1263501849535,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 8,
-      "x": -1212.9770236291079,
-      "y": 2844.0141447947553,
-      "type": "path",
-      "move_mode": "fly",
-      "action": "",
-      "action_params": ""
-    },
-    {
-      "id": 9,
-      "x": -1316.5,
-      "y": 2824.9094733135644,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 10,
-      "x": -1350.5,
-      "y": 2928.9629663555497,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 11,
-      "x": -1404.9970915986214,
-      "y": 2914.502828958952,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "target"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -1273.47,
+            "y": 2722.32,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -1260.5,
+            "y": 2806.0,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": -1191,
+            "y": 2805.47,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": ",wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -1191,
+            "y": 2805.47,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": ",wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 5,
+            "x": -1191,
+            "y": 2805.47,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": ",wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 6,
+            "x": -1193.5,
+            "y": 2808.13,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": ",wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 7,
+            "x": -1189.0,
+            "y": 2808.13,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path",
+            "locked": false
+        },
+        {
+            "id": 8,
+            "x": -1212.98,
+            "y": 2844.01,
+            "type": "path",
+            "move_mode": "fly",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 9,
+            "x": -1316.5,
+            "y": 2824.91,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 10,
+            "x": -1350.5,
+            "y": 2928.96,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 11,
+            "x": -1405.0,
+            "y": 2914.5,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-坠星山谷望风角和摘星崖-2个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-坠星山谷望风角和摘星崖-2个.json
@@ -1,88 +1,88 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-坠星山谷望风角和摘星崖-2个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-2个\n蒙德-坠星山谷望风角和摘星崖",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -1629.0499999999993,
-      "y": 2835.0200000000004,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-坠星山谷望风角和摘星崖-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-2个\n蒙德-坠星山谷望风角和摘星崖",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -1657.7440377771727,
-      "y": 2751.252443191821,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 3,
-      "x": -1655.3123909349488,
-      "y": 2740.6257072397384,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 4,
-      "x": -1657.499418319725,
-      "y": 2744.812017791088,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 5,
-      "x": -1652.9384815854646,
-      "y": 2744.000128589043,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 6,
-      "x": -1652.9360094442927,
-      "y": 2744.002443191821,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 7,
-      "x": -1559.08,
-      "y": 2492.51,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
-    },
-    {
-      "id": 8,
-      "x": -1572,
-      "y": 2533.4120450944283,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "target"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -1629.05,
+            "y": 2835.02,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -1657.74,
+            "y": 2751.25,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": -1655.31,
+            "y": 2740.63,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -1657.5,
+            "y": 2744.81,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 5,
+            "x": -1652.94,
+            "y": 2744.0,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 6,
+            "x": -1652.94,
+            "y": 2744.0,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path",
+            "locked": false
+        },
+        {
+            "id": 7,
+            "x": -1559.08,
+            "y": 2492.51,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 8,
+            "x": -1572,
+            "y": 2533.41,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-苍风高地晨曦酒庄湖中和湖边崖上-2个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-苍风高地晨曦酒庄湖中和湖边崖上-2个.json
@@ -1,97 +1,97 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-苍风高地晨曦酒庄湖中和湖边崖上-2个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-1个\n蒙德-龙脊雪山",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -321.72999999999956,
-      "y": 1470.2700000000004,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-苍风高地晨曦酒庄湖中和湖边崖上-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄湖中和湖边崖上",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -273.5623909349488,
-      "y": 1590.624871410957,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 3,
-      "x": -274.1246728048445,
-      "y": 1593.812371410957,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 4,
-      "x": -270.2481095391031,
-      "y": 1592.0029575479948,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 5,
-      "x": -272.9991638346037,
-      "y": 1592.1871785273925,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path",
-      "locked": false
-    },
-    {
-      "id": 6,
-      "x": -265.500581680275,
-      "y": 1603.249357054783,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 7,
-      "x": -223.65321149337433,
-      "y": 1689.3506966708283,
-      "action": "stop_flying",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 8,
-      "x": -225.73902078479477,
-      "y": 1691.273146027781,
-      "type": "path",
-      "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)"
-    },
-    {
-      "id": 9,
-      "x": -223.65321149337433,
-      "y": 1689.3506966708283,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "target"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -321.73,
+            "y": 1470.27,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -273.56,
+            "y": 1590.62,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 3,
+            "x": -274.12,
+            "y": 1593.81,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 4,
+            "x": -270.25,
+            "y": 1592.0,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target",
+            "locked": false
+        },
+        {
+            "id": 5,
+            "x": -273.0,
+            "y": 1592.19,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path",
+            "locked": false
+        },
+        {
+            "id": 6,
+            "x": -265.5,
+            "y": 1603.25,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 7,
+            "x": -223.65,
+            "y": 1689.35,
+            "action": "stop_flying",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 8,
+            "x": -225.74,
+            "y": 1691.27,
+            "type": "target",
+            "move_mode": "walk",
+            "action": "combat_script",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f),wait(0.1),keypress(f)"
+        },
+        {
+            "id": 9,
+            "x": -223.65,
+            "y": 1689.35,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-苍风高地晨曦酒庄西南崖上-2个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-苍风高地晨曦酒庄西南崖上-2个.json
@@ -1,102 +1,102 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-苍风高地晨曦酒庄西南崖上-2个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄西南崖上",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -321.72999999999956,
-      "y": 1470.2700000000004,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-苍风高地晨曦酒庄西南崖上-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄西南崖上",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -269.5,
-      "y": 1479.5,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 3,
-      "x": -223.2495637397933,
-      "y": 1497.0041148493838,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 4,
-      "x": -176.74505571765621,
-      "y": 1483.497556808179,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 5,
-      "x": -115.5,
-      "y": 1505.4213035055418,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 6,
-      "x": -110.12405476955246,
-      "y": 1485.625,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path"
-    },
-    {
-      "id": 7,
-      "x": -109.99898205951831,
-      "y": 1485.625,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 8,
-      "x": -115,
-      "y": 1537.9303047385674,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 9,
-      "x": -108.2515996207585,
-      "y": 1563.7490355821756,
-      "action": "stop_flying",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 10,
-      "x": -108.2515996207585,
-      "y": 1563.7490355821756,
-      "action": "fight",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "target"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -321.73,
+            "y": 1470.27,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -269.5,
+            "y": 1479.5,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": -223.25,
+            "y": 1497.0,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 4,
+            "x": -176.75,
+            "y": 1483.5,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 5,
+            "x": -115.5,
+            "y": 1505.42,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 6,
+            "x": -110.12,
+            "y": 1485.62,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target"
+        },
+        {
+            "id": 7,
+            "x": -110.0,
+            "y": 1485.62,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 8,
+            "x": -115,
+            "y": 1537.93,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 9,
+            "x": -108.25,
+            "y": 1563.75,
+            "action": "stop_flying",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 10,
+            "x": -108.25,
+            "y": 1563.75,
+            "action": "fight",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "target"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-苍风高地晨曦酒庄西南石门北-2个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-苍风高地晨曦酒庄西南石门北-2个.json
@@ -1,147 +1,147 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-苍风高地晨曦酒庄西南石门北-2个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄西南石门北",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": 207.6900000000005,
-      "y": 1573.6399999999994,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-苍风高地晨曦酒庄西南石门北-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-2个\n蒙德-苍风高地晨曦酒庄西南石门北",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": 184.4978186989665,
-      "y": 1605.998585520525,
-      "type": "path",
-      "move_mode": "run",
-      "action": "",
-      "action_params": ""
-    },
-    {
-      "id": 3,
-      "x": 163.25,
-      "y": 1623.9466355470577,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 4,
-      "x": 142.25,
-      "y": 1632.7011361635723,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 5,
-      "x": 118.75,
-      "y": 1647.458722917123,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 6,
-      "x": 106.49934560968904,
-      "y": 1657.250642945217,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
-      "type": "path"
-    },
-    {
-      "id": 7,
-      "x": 107.43775448512133,
-      "y": 1653.687628589043,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 8,
-      "x": 101.7515996207585,
-      "y": 1637.8739069931326,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 9,
-      "x": 85.75,
-      "y": 1673.958079971906,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 10,
-      "x": 86.74985457993171,
-      "y": 1719.6281504315593,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 11,
-      "x": 64.7492728996549,
-      "y": 1709.000385767129,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 12,
-      "x": 41,
-      "y": 1703.4732534790073,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 13,
-      "x": 36.25,
-      "y": 1707.4753109036992,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 14,
-      "x": 31.75,
-      "y": 1713.228268451694,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 15,
-      "x": 16.87347308927565,
-      "y": 1729.748714109568,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "target"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": 207.69,
+            "y": 1573.64,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": 184.5,
+            "y": 1606.0,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 3,
+            "x": 163.25,
+            "y": 1623.95,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 4,
+            "x": 142.25,
+            "y": 1632.7,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 5,
+            "x": 118.75,
+            "y": 1647.46,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 6,
+            "x": 106.5,
+            "y": 1657.25,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1),keypress(f),wait(0.1),keypress(f)",
+            "type": "target"
+        },
+        {
+            "id": 7,
+            "x": 107.44,
+            "y": 1653.69,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 8,
+            "x": 101.75,
+            "y": 1637.87,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 9,
+            "x": 85.75,
+            "y": 1673.96,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 10,
+            "x": 86.75,
+            "y": 1719.63,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 11,
+            "x": 64.75,
+            "y": 1709.0,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 12,
+            "x": 41,
+            "y": 1703.47,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 13,
+            "x": 36.25,
+            "y": 1707.48,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 14,
+            "x": 31.75,
+            "y": 1713.23,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 15,
+            "x": 16.87,
+            "y": 1729.75,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-风啸山坡达达乌帕谷西方略偏北-2个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-风啸山坡达达乌帕谷西方略偏北-2个.json
@@ -1,129 +1,129 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-风啸山坡达达乌帕谷西方略偏北-2个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-2个\n蒙德-风啸山坡达达乌帕谷西方略偏北",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -1136.5100000000002,
-      "y": 1595.3600000000006,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-风啸山坡达达乌帕谷西方略偏北-2个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-2个\n蒙德-风啸山坡达达乌帕谷西方略偏北",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -1181.5,
-      "y": 1547.9056156422666,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 3,
-      "x": -1216,
-      "y": 1551.9076730669585,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 4,
-      "x": -1221.8744910297592,
-      "y": 1549.6246785273925,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.5),keypress(f),wait(0.5),keypress(f),wait(0.5),keypress(f)",
-      "type": "path"
-    },
-    {
-      "id": 5,
-      "x": -1221.749418319725,
-      "y": 1549.749742821914,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 6,
-      "x": -1217.5,
-      "y": 1499.3806693678798,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 7,
-      "x": -1215.2504362602067,
-      "y": 1490.2518002466059,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 8,
-      "x": -1212,
-      "y": 1447.854180024975,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 9,
-      "x": -1256.5,
-      "y": 1413.246270917747,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 10,
-      "x": -1283,
-      "y": 1393.3261476135503,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 11,
-      "x": -1300,
-      "y": 1379.8192038052148,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 12,
-      "x": -1319.7489820595183,
-      "y": 1380.7519288356489,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.5),keypress(f),wait(0.5),keypress(f),wait(0.5),keypress(f)",
-      "type": "path"
-    },
-    {
-      "id": 13,
-      "x": -1319.7489820595183,
-      "y": 1380.7519288356489,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "target"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -1136.51,
+            "y": 1595.36,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -1181.5,
+            "y": 1547.91,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": -1216,
+            "y": 1551.91,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 4,
+            "x": -1221.87,
+            "y": 1549.62,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.5),keypress(f),wait(0.5),keypress(f),wait(0.5),keypress(f)",
+            "type": "target"
+        },
+        {
+            "id": 5,
+            "x": -1221.75,
+            "y": 1549.75,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 6,
+            "x": -1217.5,
+            "y": 1499.38,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 7,
+            "x": -1215.25,
+            "y": 1490.25,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 8,
+            "x": -1212,
+            "y": 1447.85,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 9,
+            "x": -1256.5,
+            "y": 1413.25,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 10,
+            "x": -1283,
+            "y": 1393.33,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 11,
+            "x": -1300,
+            "y": 1379.82,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 12,
+            "x": -1319.75,
+            "y": 1380.75,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.5),keypress(f),wait(0.5),keypress(f),wait(0.5),keypress(f)",
+            "type": "target"
+        },
+        {
+            "id": 13,
+            "x": -1319.75,
+            "y": 1380.75,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "target"
+        }
+    ]
 }

--- a/repo/pathing/骗骗花/蒙德-骗骗花-风啸山坡风起地西南方-3个.json
+++ b/repo/pathing/骗骗花/蒙德-骗骗花-风啸山坡风起地西南方-3个.json
@@ -1,93 +1,93 @@
 {
-  "info": {
-    "name": "蒙德-骗骗花-风啸山坡风起地西南方-3个",
-    "type": "collect",
-    "author": "提瓦特钓鱼玳师",
-    "version": "1.0",
-    "description": "骗骗花-3个\n蒙德-风啸山坡风起地西南方",
-    "bgiVersion": "0.35.1"
-  },
-  "positions": [
-    {
-      "id": 1,
-      "x": -1136.5100000000002,
-      "y": 1595.3600000000006,
-      "action": "",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "teleport"
+    "info": {
+        "name": "蒙德-骗骗花-风啸山坡风起地西南方-3个",
+        "type": "collect",
+        "author": "提瓦特钓鱼玳师",
+        "version": "1.1",
+        "description": "骗骗花-3个\n蒙德-风啸山坡风起地西南方",
+        "bgiVersion": "0.42.0"
     },
-    {
-      "id": 2,
-      "x": -1158.75,
-      "y": 1630.9558939581711,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 3,
-      "x": -1162.0351916566833,
-      "y": 1663.9917703012325,
-      "type": "path",
-      "move_mode": "run",
-      "action": "",
-      "action_params": ""
-    },
-    {
-      "id": 4,
-      "x": -1134.2680320885484,
-      "y": 1710.5072009864216,
-      "type": "path",
-      "move_mode": "run",
-      "action": "",
-      "action_params": ""
-    },
-    {
-      "id": 5,
-      "x": -1044.25,
-      "y": 1728.9634807117218,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 6,
-      "x": -1094,
-      "y": 1758.3888990666474,
-      "action": "",
-      "move_mode": "run",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 7,
-      "x": -1155.5,
-      "y": 1765.892756737945,
-      "action": "",
-      "move_mode": "fly",
-      "action_params": "",
-      "type": "path"
-    },
-    {
-      "id": 8,
-      "x": -1197.6249272899659,
-      "y": 1757.999485643828,
-      "action": "combat_script",
-      "move_mode": "walk",
-      "action_params": "wait(0.1).kepress(f),wait(0.1).kepress(f),wait(0.1).kepress(f)",
-      "type": "path"
-    },
-    {
-      "id": 9,
-      "x": -1197.6249272899659,
-      "y": 1757.999485643828,
-      "action": "fight",
-      "move_mode": "walk",
-      "action_params": "",
-      "type": "path"
-    }
-  ]
+    "positions": [
+        {
+            "id": 1,
+            "x": -1136.51,
+            "y": 1595.36,
+            "action": "",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "teleport"
+        },
+        {
+            "id": 2,
+            "x": -1158.75,
+            "y": 1630.96,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 3,
+            "x": -1162.04,
+            "y": 1663.99,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 4,
+            "x": -1134.27,
+            "y": 1710.51,
+            "type": "path",
+            "move_mode": "run",
+            "action": "",
+            "action_params": ""
+        },
+        {
+            "id": 5,
+            "x": -1044.25,
+            "y": 1728.96,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 6,
+            "x": -1094,
+            "y": 1758.39,
+            "action": "",
+            "move_mode": "run",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 7,
+            "x": -1155.5,
+            "y": 1765.89,
+            "action": "",
+            "move_mode": "fly",
+            "action_params": "",
+            "type": "path"
+        },
+        {
+            "id": 8,
+            "x": -1197.62,
+            "y": 1758.0,
+            "action": "combat_script",
+            "move_mode": "walk",
+            "action_params": "wait(0.1).kepress(f),wait(0.1).kepress(f),wait(0.1).kepress(f)",
+            "type": "target"
+        },
+        {
+            "id": 9,
+            "x": -1197.62,
+            "y": 1758.0,
+            "action": "fight",
+            "move_mode": "walk",
+            "action_params": "",
+            "type": "path"
+        }
+    ]
 }


### PR DESCRIPTION
全是下落攻击实现的，地区是蒙德和璃月
由秋云大佬指正，修复了部分骗骗花交互点位的type为target