### PR TITLE
path: 添加推荐伐木点的路径追踪 （配合独立任务中的自动伐木功能使用）

### DIFF
--- a/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 悬铃木x18.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 悬铃木x18.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[枫丹] 悬铃木x18",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 4683.80322265625,
+      "y": 2426.124755859375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 4597.6328125,
+      "y": 2353.38916015625,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 4569.02001953125,
+      "y": 2341.4970703125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 椴木x9 + 悬铃木x9.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 椴木x9 + 悬铃木x9.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[枫丹] 椴木x9 + 悬铃木x9",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 3383.1943359375,
+      "y": 2692.22314453125,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 3367.9716796875,
+      "y": 2700.928466796875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 3249.283203125,
+      "y": 2761.09814453125,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": "1000"
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 椴木x9.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 椴木x9.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "[枫丹] 椴木x9",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 4984.4609375,
+      "y": 1699.88134765625,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 4977.05322265625,
+      "y": 1713.58203125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 4980.44189453125,
+      "y": 1734.904296875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 4975.56640625,
+      "y": 1811.01416015625,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 炬木x15.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 炬木x15.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[枫丹] 炬木x15",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 4704.083984375,
+      "y": 2376.86669921875,
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
+    },
+    {
+      "id": 2,
+      "x": 4683.68701171875,
+      "y": 2389.752197265625,
+      "action": "log_output",
+      "move_mode": "walk",
+      "action_params": "目前不支持非地面点位的路径追踪，请向东方向前行到墙边",
+      "type": "orientation"
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 白梣木x15.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 白梣木x15.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[枫丹] 白梣木x15",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "action": "",
+      "move_mode": "walk",
+      "type": "teleport",
+      "x": 4689.51904296875,
+      "y": 2429.276611328125,
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 4731.1494140625,
+      "y": 2477.20361328125,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 香柏木x27.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[枫丹] 香柏木x27.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[枫丹] 香柏木x27",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 3923.0693359375,
+      "y": 4233.8671875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 3921.4736328125,
+      "y": 4196.3671875,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[璃月] 却砂木x12.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[璃月] 却砂木x12.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[璃月] 却砂木x12",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 340.9365234375,
+      "y": 547.91259765625,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 401.0791015625,
+      "y": 499.00390625,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 417.9228515625,
+      "y": 485.568359375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[璃月] 竹节x30.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[璃月] 竹节x30.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[璃月] 竹节x30",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 843.09375,
+      "y": 1532.849609375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 808.3974609375,
+      "y": 1515.33984375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 孔雀木x9 + 御伽木x6.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 孔雀木x9 + 御伽木x6.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[稻妻] 孔雀木x9 + 御伽木x6",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -4429.8125,
+      "y": -2798.57421875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -4458.048828125,
+      "y": -2812.5673828125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 御伽木x9 + 孔雀木x6.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 御伽木x9 + 孔雀木x6.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[稻妻] 御伽木x9 + 孔雀木x6",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -4217.869140625,
+      "y": -2397.865234375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -4185.3984375,
+      "y": -2430.158203125,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": "2000"
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 枫木x9.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 枫木x9.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "[稻妻] 枫木x9",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -3812.810546875,
+      "y": -2547.3427734375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -3809.3671875,
+      "y": -2577.1220703125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -3796.8505859375,
+      "y": -2604.203125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": -3759.8125,
+      "y": -2594.4453125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 梦见木x12.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[稻妻] 梦见木x12.json
@@ -1,0 +1,66 @@
+{
+  "info": {
+    "name": "[稻妻] 梦见木x12",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -4232.17578125,
+      "y": -3003.2158203125,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -4219.541015625,
+      "y": -2982.3671875,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -4138.595703125,
+      "y": -2970.5,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": -4065.251953125,
+      "y": -2997.798828125,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": -4005.177734375,
+      "y": -2972.4296875,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": -3999.3955078125,
+      "y": -2976.142578125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 桃椰子木x12.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 桃椰子木x12.json
@@ -1,0 +1,31 @@
+{
+  "info": {
+    "name": "[纳塔] 桃椰子木x12",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 8350.158203125,
+      "y": -2843.5556640625,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": "",
+      "locked": false
+    },
+    {
+      "id": 2,
+      "x": 8381.07421875,
+      "y": -2823.087890625,
+      "type": "orientation",
+      "move_mode": "walk",
+      "action": "log_output",
+      "action_params": "当前暂不支持分层地图的路径追踪，请手动前往（神像五点钟方向的小山包）"
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 灰灰楼林木x9.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 灰灰楼林木x9.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "name": "[纳塔] 灰灰楼林木x9",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 9757.900390625,
+      "y": -613.65771484375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 9766.7333984375,
+      "y": -603.93212890625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 9774.1640625,
+      "y": -613.4931640625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 9809.4599609375,
+      "y": -656.9931640625,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 9813.7685546875,
+      "y": -663.6298828125,
+      "type": "target",
+      "move_mode": "climb",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 燃爆木x15.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 燃爆木x15.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "[纳塔] 燃爆木x15",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 9039.0693359375,
+      "y": -2428.6201171875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 9034.5234375,
+      "y": -2447.1689453125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 9033.30078125,
+      "y": -2452.609375,
+      "type": "path",
+      "move_mode": "climb",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 9049.291015625,
+      "y": -2513.6337890625,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 白栗栎木x9.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[纳塔] 白栗栎木x9.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "[纳塔] 白栗栎木x9",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 8058.86181640625,
+      "y": -2372.5966796875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 8068.009765625,
+      "y": -2379.6435546875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 8086.94287109375,
+      "y": -2394.7197265625,
+      "type": "path",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 8146.4697265625,
+      "y": -2439.9921875,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 垂香木x15.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 垂香木x15.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[蒙德] 垂香木",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -521.623046875,
+      "y": 2181.329833984375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -537.1240234375,
+      "y": 2175.3076171875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -541.736328125,
+      "y": 2160.890625,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 杉木x18.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 杉木x18.json
@@ -1,0 +1,58 @@
+{
+  "info": {
+    "name": "[蒙德] 杉木x18",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -251.591796875,
+      "y": 2256.58984375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -231.8388671875,
+      "y": 2219.850341796875,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -221.59375,
+      "y": 2218.249755859375,
+      "type": "path",
+      "move_mode": "climb",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": -154.837890625,
+      "y": 2198.947509765625,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": -28.115234375,
+      "y": 2163.086181640625,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": "",
+      "locked": false
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 松木x24.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 松木x24.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[蒙德] 松木x24",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -749.4052734375,
+      "y": 2263.125,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -784.896484375,
+      "y": 2303.740234375,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 桦木x18.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 桦木x18.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[蒙德] 桦木x18",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -1330.107421875,
+      "y": 2563.807373046875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -1367.8466796875,
+      "y": 2571.372314453125,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -1376.634765625,
+      "y": 2580.2109375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 萃华木x6 + 垂香木x3.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[蒙德] 萃华木x6 + 垂香木x3.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[蒙德] 萃华木x6 + 垂香木x3",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": -1120.86328125,
+      "y": 2190.60888671875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": -1152.7080078125,
+      "y": 2170.24365234375,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": -1155.90234375,
+      "y": 2175.06591796875,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 业果木x21 + 辉木x3.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 业果木x21 + 辉木x3.json
@@ -1,0 +1,39 @@
+{
+  "info": {
+    "name": "[须弥] 业果木x21 + 辉木x3",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 3135.63671875,
+      "y": -1079.6572265625,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 3166.373046875,
+      "y": -1080.20654296875,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 3175.55078125,
+      "y": -1064.35888671875,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 刺葵木x6.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 刺葵木x6.json
@@ -1,0 +1,30 @@
+{
+  "info": {
+    "name": "[须弥] 刺葵木x6",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 4209.84130859375,
+      "y": -2712.0947265625,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 4203.99462890625,
+      "y": -2730.2568359375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 柽木x15.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 柽木x15.json
@@ -1,0 +1,48 @@
+{
+  "info": {
+    "name": "[须弥] 柽木x15",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 4095.984375,
+      "y": -2025.97412109375,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 4120.65185546875,
+      "y": -2047.38671875,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 4148.99365234375,
+      "y": -2041.66357421875,
+      "type": "path",
+      "move_mode": "dash",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 4218.1259765625,
+      "y": -2061.7998046875,
+      "type": "target",
+      "move_mode": "fly",
+      "action": "stop_flying",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 证悟木x18 + 业果木x6.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 证悟木x18 + 业果木x6.json
@@ -1,0 +1,57 @@
+{
+  "info": {
+    "name": "[须弥] 证悟木x18 + 业果木x6",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 3135.6884765625,
+      "y": -1079.6435546875,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 3149.046875,
+      "y": -1088.2412109375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 3149.900390625,
+      "y": -1104.6689453125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 3164.40234375,
+      "y": -1127.8310546875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 3158.82421875,
+      "y": -1138.740234375,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}

--- a/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 辉木x21 + 业果木x6.json
+++ b/repo/pathing/木材伐木点-配合自动伐木使用/[须弥] 辉木x21 + 业果木x6.json
@@ -1,0 +1,66 @@
+{
+  "info": {
+    "name": "[须弥] 辉木x21 + 业果木x6",
+    "type": "collect",
+    "author": "Patrick-Ze (AyakaMain)",
+    "version": "1.0",
+    "description": "",
+    "bgiVersion": "0.42.3"
+  },
+  "positions": [
+    {
+      "id": 1,
+      "x": 3145.435546875,
+      "y": -1079.84033203125,
+      "type": "teleport",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 2,
+      "x": 3160.798828125,
+      "y": -1080.49169921875,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
+      "x": 3179.044921875,
+      "y": -1062.67236328125,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 4,
+      "x": 3198.0546875,
+      "y": -1076.755859375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 5,
+      "x": 3206.8642578125,
+      "y": -1064.88818359375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 6,
+      "x": 3202.689453125,
+      "y": -1057.3876953125,
+      "type": "target",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    }
+  ]
+}


### PR DESCRIPTION
具体点位参考了自动伐木功能的文档。
由于部分点位过于刁钻，地图追踪精度可能达不到同时最大伐木数（会漏一棵树），特别是分辨率低时。如果介意，这种情况只能在自动追踪后精调位置（通常只需要走一小步就行）。