### PR TITLE
js: 七圣召唤七日历练: 修复因OCR区域过大导致牌手姓名可能误识别的问题

### DIFF
--- a/repo/js/七圣召唤七日历练全自动/main.js
+++ b/repo/js/七圣召唤七日历练全自动/main.js
@@ -204,7 +204,7 @@ async function captureAndStoreTexts() {
 
     // 截取区域大小
     const width = 240;
-    const height = 100;
+    const height = 56;
     await sleep(500);
     keyPress("F6");
     await sleep(1000);

--- a/repo/js/七圣召唤七日历练全自动/manifest.json
+++ b/repo/js/七圣召唤七日历练全自动/manifest.json
@@ -1,12 +1,12 @@
 {
   "manifest_version": 1,
   "name": "打牌一条龙",
-  "version": "1.91",
+  "version": "1.9.2",
   "description": "只靠一个牌组的话，胜率还是太低了，所以有没有既简单又强势的卡组推荐下呢？",
   "authors": [
     {
-        "name": "柒叶子",
-        "link": "https://github.com/511760049"
+      "name": "柒叶子",
+      "link": "https://github.com/5117600049"
     }
   ],
   "settings_ui": "settings.json",


### PR DESCRIPTION
默认的OCR区域过大
![image](https://github.com/user-attachments/assets/f57c86f1-515c-4f2e-b4c7-c68539e3a3d1)
导致部分情况下会引入换行，并且花纹被识别为符号`?`
![image](https://github.com/user-attachments/assets/7fd867e1-1f26-43c0-b1db-1f934e38efec)

在牌桌附近寻找牌手时，会找不到叫`帕班<换行>?`的牌手而失败

此PR调整了OCR区域的大小以避免这种情况：

![image](https://github.com/user-attachments/assets/7578b970-9067-43a4-8ae8-68713668cd7b)

![image](https://github.com/user-attachments/assets/42eedd84-c1b3-494b-8802-5aa7f84ccd26)
