### PR TITLE
feat: 添加切换队伍脚本

### DIFF
--- a/repo/js/SwitchTeam/main.js
+++ b/repo/js/SwitchTeam/main.js
@@ -1,0 +1,3 @@
+(async function () {
+    await genshin.switchParty(settings.partyName)
+})();

--- a/repo/js/SwitchTeam/manifest.json
+++ b/repo/js/SwitchTeam/manifest.json
@@ -1,0 +1,17 @@
+{
+    "manifest_version": 1,
+    "name": "SwitchTeam", 
+    "version": "1.0", 
+    "bgi_version": "0.36.1", 
+    "description": "切换到配置的队伍，在自定义配置中添加需要切换的队伍名称", 
+   
+    "authors": [
+      {
+        "name": "Lochinor",
+        "link": "https://github.com/Lochinor"
+      }
+    ],
+   
+    "settings_ui": "settings.json",
+    "main": "main.js"
+  }

--- a/repo/js/SwitchTeam/settings.json
+++ b/repo/js/SwitchTeam/settings.json
@@ -1,0 +1,7 @@
+[
+    {
+        "name": "partyName",
+        "type": "input-text",
+        "label": "切换的队伍名称"
+    }
+]


### PR DESCRIPTION
方便在调用其他脚本中添加切换队伍的脚本，如抓取晶蝶前自动切换到配置的队伍，如有其他方案请忽略