### PR TITLE
[js]联机吃金币活动：将联机被拒绝时的处理改为超时检测

### DIFF
--- a/repo/js/AutoEatCoinPVPEvent/main.js
+++ b/repo/js/AutoEatCoinPVPEvent/main.js
@@ -107,7 +107,7 @@
             return;
         }
         log.info("积分状态: {current}/{max}", currentScore, maxScore);
-        if (1 >= maxScore) {
+        if (currentScore >= maxScore) {
             log.info("PVP活动已完成");
             // notification.send("PVP活动已完成");
             await genshin.returnMainUi();


### PR DESCRIPTION
将联机被拒绝时的处理改为超时检测（自测发现原先的有概率处理失败）

增加了一个彩蛋