### PR TITLE
JS脚本：提瓦特全自动钓鱼【修复】

### DIFF
--- a/repo/js/AutoFishingTeyvat/main.js
+++ b/repo/js/AutoFishingTeyvat/main.js
@@ -196,6 +196,12 @@
         let content = {};
         if (assets_dir.includes("assets\\archive.json")) {
             content = JSON.parse(file.readTextSync("assets/archive.json"));
+            if (!Object.keys(content).includes(user_id)) {
+                content[user_id] = {};
+            }
+            if (!Object.keys(content[user_id]).includes(pathing_name)) {
+                content[user_id][pathing_name] = {};
+            }
             if (time_status === "全天") {
                 content[user_id][pathing_name]["Daytime"] = timestamp;
                 content[user_id][pathing_name]["Nighttime"] = timestamp;
@@ -284,11 +290,11 @@
             let regex_area, regex_fish, regex_bait;
 
             // 读取地区
-            let path_sort_area = typeof(settings.path_sort_area) === 'undefined' ? [] : settings.path_sort_area.split(' ');
+            let path_sort_area = typeof(settings.path_sort_area) === 'undefined' || settings.path_sort_area === "" ? [] : settings.path_sort_area.split(' ');
             // 读取鱼类
-            let path_sort_fish = typeof(settings.path_sort_fish) === 'undefined' ? [] : settings.path_sort_fish.split(' ');
+            let path_sort_fish = typeof(settings.path_sort_fish) === 'undefined' || settings.path_sort_fish === "" ? [] : settings.path_sort_fish.split(' ');
             // 读取鱼饵
-            let path_sort_bait = typeof(settings.path_sort_bait) === 'undefined' ? [] : settings.path_sort_bait.split(' ');
+            let path_sort_bait = typeof(settings.path_sort_bait) === 'undefined' || settings.path_sort_bait === "" ? [] : settings.path_sort_bait.split(' ');
             // 读取兑换材料
             let path_sort_material = typeof(settings.path_sort_material) === 'undefined' ? "无(默认)" : settings.path_sort_material;
             // 读取调试信息

--- a/repo/js/AutoFishingTeyvat/manifest.json
+++ b/repo/js/AutoFishingTeyvat/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "提瓦特自动钓鱼（全流程+自选）",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "bgi_version": "0.47.0",
   "description": "支持自动追踪并垂钓bgi支持的全提瓦特垂钓点",
   "authors": [


### PR DESCRIPTION
1. 修复了JS脚本配置中文本框为空可能导致的问题
2. 修复了启用CD计算后钓完第二个钓鱼点后会出现报错的问题

CD计算逻辑仍待测试，目前为等待72小时