### PR TITLE
修复OCR购买食材脚本中，寻找NPC重试不能成功的问题

### DIFF
--- a/repo/js/OCR购买食材/main.js
+++ b/repo/js/OCR购买食材/main.js
@@ -326,6 +326,7 @@ async function checkNpcAndFAlignment(npcName, fDialogueRo) {
             }
 
             // 检查是否找到 F 图标
+            ra = captureGameRegion();
             fRes = ra.find(fDialogueRo); // 重新查找 F 图标
             if (fRes.isExist()) {
                 log.info("找到 F 图标");


### PR DESCRIPTION
问题的原因在于，挪动角色后没有重新截图，仍然使用旧的截图寻找F气泡，一定找不到，所以重试一定不能成功