### PR TITLE
fix: 修复邀请函购买逻辑，避免超过邀请函数量上限导致任务卡死

### DIFF
--- a/repo/js/七圣召唤角色邀约全自动/main.js
+++ b/repo/js/七圣召唤角色邀约全自动/main.js
@@ -175,7 +175,7 @@ await genshin.returnMainUi();
 log.info(`开始执行角色邀约挑战`);
 for (let i = 0; i < challengeNumber; i++) {
    await gotoTavern();
-   if (challengeNumber-letterNumber > 0) {
+   if (letterNumber <= i) {
        log.info(`购买第${i+1}次`);
        await BuyLetter();
        letterNumber++;


### PR DESCRIPTION
## 问题说明

原始逻辑中在挑战开始前判断是否需要购买邀请函：

```js
if (challengeNumber - letterNumber > 0) {
    await BuyLetter();
    letterNumber++;
}
```
判断条件有问题：`challengeNumber-letterNumber > 0` 导致在**邀请函不足**且**已有角色被提前邀请**的情况下，前几轮循环都会进行购买，但由于角色**已被邀请**而未进行挑战，无法消耗邀请函，邀请函被积累，可能触发游戏内“最多持有10个邀请函”的限制，从而导致无法继续执行脚本（卡住、卡UI等）。

实际执行情况举例：挑战人数 = 5，邀请函数量 = 2

第1次：5-2=3>0，购买，letterNumber变成3
第2次：5-3=2>0，购买，letterNumber变成4
第3次：5-4=1>0，购买，letterNumber变成5
第4次：5-5=0，不购买
第5次：5-5=0，不购买

实际游戏中邀请函有最多持有上限为 10 个，超出后将会：
无法购买更多邀请函
按键/对话卡住，脚本逻辑无法继续执行，导致整个任务流程被阻塞

##修复方案
改动将：

修改判断逻辑为 `if (letterNumber <= i)`，在每次挑战前检查是否有足够的邀请函

实际执行举例： 假设挑战人数=5，初始邀请函数量=2

第1次循环 (i=0)：letterNumber=2 > 0，不购买，使用现有邀请函
第2次循环 (i=1)：letterNumber=2 > 1，不购买，使用现有邀请函
第3次循环 (i=2)：letterNumber=2 <= 2，购买，letterNumber变成3
第4次循环 (i=3)：letterNumber=3 <= 3，购买，letterNumber变成4
第5次循环 (i=4)：letterNumber=4 <= 4，购买，letterNumber变成5

修改示例
```js
for (let i = 0; i < challengeNumber; i++) {
    await gotoTavern();

    if (letterNumber <= i) {
        await BuyLetter();
        letterNumber++;
    }
    ...
