### PR TITLE
校准水晶块路线

### DIFF
--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/层岩巨渊·地下矿区/11-水晶块-层岩巨渊·地下矿区-临时主矿道-南2-4个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/层岩巨渊·地下矿区/11-水晶块-层岩巨渊·地下矿区-临时主矿道-南2-4个.json
@@ -187,8 +187,8 @@
     },
     {
       "id": 20,
-      "x": 736.77,
-      "y": 857.04,
+      "x": 737.555908203125,
+      "y": 858.388916015625,
       "action": "combat_script",
       "move_mode": "walk",
       "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2)",

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/沉玉谷/05-水晶块-沉玉谷-暝垣山北-3个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/沉玉谷/05-水晶块-沉玉谷-暝垣山北-3个.json
@@ -47,7 +47,7 @@
       "y": 2517.26,
       "action": "stop_flying",
       "move_mode": "fly",
-      "action_params": "3000",
+      "action_params": "3500",
       "type": "path"
     },
     {

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/16-水晶块-璃月-庆云顶东-7个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/16-水晶块-璃月-庆云顶东-7个.json
@@ -178,8 +178,8 @@
     },
     {
       "id": 19,
-      "x": 1276.35,
-      "y": 757.44,
+      "x": 1276.8232421875,
+      "y": 757.9697265625,
       "action": "combat_script",
       "move_mode": "walk",
       "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/蒙德/03-水晶块-蒙德-奔狼领-5个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/蒙德/03-水晶块-蒙德-奔狼领-5个.json
@@ -25,6 +25,15 @@
     },
     {
       "id": 2,
+      "x": -548.24609375,
+      "y": 2168.119140625,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 3,
       "x": -580.53,
       "y": 2151.68,
       "action": "",
@@ -33,7 +42,7 @@
       "type": "path"
     },
     {
-      "id": 3,
+      "id": 4,
       "x": -582.57,
       "y": 2152.01,
       "action": "combat_script",
@@ -42,7 +51,7 @@
       "type": "target"
     },
     {
-      "id": 4,
+      "id": 5,
       "x": -582.18,
       "y": 2151.51,
       "action": "combat_script",
@@ -51,7 +60,7 @@
       "type": "target"
     },
     {
-      "id": 5,
+      "id": 6,
       "x": -583.65,
       "y": 2148.86,
       "action": "combat_script",
@@ -60,7 +69,7 @@
       "type": "target"
     },
     {
-      "id": 6,
+      "id": 7,
       "x": -581.96,
       "y": 2147.8,
       "type": "target",
@@ -69,7 +78,7 @@
       "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
     },
     {
-      "id": 7,
+      "id": 8,
       "x": -584.92,
       "y": 2145.81,
       "action": "combat_script",
@@ -78,7 +87,7 @@
       "type": "target"
     },
     {
-      "id": 8,
+      "id": 9,
       "x": -587.75,
       "y": 2143.6,
       "action": "combat_script",
@@ -87,7 +96,7 @@
       "type": "target"
     },
     {
-      "id": 9,
+      "id": 10,
       "x": -589.85,
       "y": 2145.07,
       "action": "combat_script",
@@ -96,7 +105,7 @@
       "type": "target"
     },
     {
-      "id": 10,
+      "id": 11,
       "x": -521.59,
       "y": 2181.4,
       "action": "",
@@ -105,7 +114,7 @@
       "type": "teleport"
     },
     {
-      "id": 11,
+      "id": 12,
       "x": -473.73,
       "y": 2180.97,
       "action": "",
@@ -114,7 +123,7 @@
       "type": "path"
     },
     {
-      "id": 12,
+      "id": 13,
       "x": -472.92,
       "y": 2175.18,
       "action": "",
@@ -123,7 +132,7 @@
       "type": "path"
     },
     {
-      "id": 13,
+      "id": 14,
       "x": -467.7,
       "y": 2171.62,
       "action": "combat_script",


### PR DESCRIPTION
* 11-水晶块-层岩巨渊·地下矿区-临时主矿道-南2-4个
校准矿点坐标

* 05-水晶块-沉玉谷-暝垣山北-3个
延长下落攻击等待时间，避免掉血

* 16-水晶块-璃月-庆云顶东-7个
校准矿点坐标，避免挖不到矿同时避免卡住

* 03-水晶块-蒙德-奔狼领-5个
添加途径点，避免卡爬树