### PR TITLE
校准璃月、沉玉谷水晶块路线

### DIFF
--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/沉玉谷/04-水晶块-沉玉谷-灵濛山北-7个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/沉玉谷/04-水晶块-沉玉谷-灵濛山北-7个.json
@@ -11,206 +11,210 @@
         "name": "火山",
         "links": "https://github.com/RRRR623"
       }
-    ]
+    ],
+    "tags": [],
+    "last_modified_time": 1755350054661,
+    "enable_monster_loot_split": false,
+    "map_match_method": ""
   },
   "positions": [
     {
       "id": 1,
-      "action": "",
-      "move_mode": "walk",
-      "type": "teleport",
       "x": 1977.26,
       "y": 2341.05,
-      "action_params": ""
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
     },
     {
       "id": 2,
       "x": 1978.05,
       "y": 2343.68,
-      "type": "path",
-      "move_mode": "walk",
       "action": "",
-      "action_params": ""
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 3,
       "x": 2031.87,
       "y": 2374.64,
-      "type": "path",
-      "move_mode": "fly",
       "action": "stop_flying",
-      "action_params": "1000"
+      "move_mode": "fly",
+      "action_params": "1000",
+      "type": "path"
     },
     {
       "id": 4,
       "x": 2031.91,
       "y": 2374.62,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 5,
       "x": 2032.56,
       "y": 2373.93,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 6,
       "x": 2031.96,
       "y": 2375.9,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 7,
       "x": 2029.25,
       "y": 2377.83,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "wait(0.5)"
+      "move_mode": "walk",
+      "action_params": "wait(0.5)",
+      "type": "target"
     },
     {
       "id": 8,
       "x": 2025.8,
       "y": 2373.36,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "wait(0.5)"
+      "move_mode": "walk",
+      "action_params": "wait(0.5)",
+      "type": "target"
     },
     {
       "id": 9,
       "x": 1977.25,
       "y": 2341.05,
-      "type": "teleport",
-      "move_mode": "walk",
       "action": "",
-      "action_params": ""
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
     },
     {
       "id": 10,
       "x": 1977.17,
       "y": 2342.73,
-      "type": "path",
-      "move_mode": "walk",
       "action": "",
-      "action_params": ""
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 11,
-      "x": 1965.13,
-      "y": 2359.57,
-      "type": "path",
-      "move_mode": "fly",
+      "x": 1963.7021484375,
+      "y": 2364.2431640625,
       "action": "stop_flying",
-      "action_params": "1000"
+      "move_mode": "fly",
+      "action_params": "1000",
+      "type": "path"
     },
     {
       "id": 12,
       "x": 1963.26,
       "y": 2359.77,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 13,
       "x": 1962.69,
       "y": 2360.89,
-      "type": "path",
-      "move_mode": "walk",
       "action": "",
-      "action_params": ""
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 14,
       "x": 1951.8,
       "y": 2356.4,
-      "type": "path",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 15,
       "x": 1952.64,
       "y": 2354.94,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 16,
       "x": 2145.66,
       "y": 2412.96,
-      "type": "teleport",
-      "move_mode": "walk",
       "action": "",
-      "action_params": ""
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
     },
     {
       "id": 17,
       "x": 2166.09,
       "y": 2410.45,
-      "type": "path",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 18,
       "x": 2177.31,
       "y": 2392.07,
-      "type": "path",
-      "move_mode": "fly",
       "action": "stop_flying",
-      "action_params": "2000"
+      "move_mode": "fly",
+      "action_params": "2000",
+      "type": "path"
     },
     {
       "id": 19,
       "x": 2177.76,
       "y": 2396.02,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 20,
       "x": 2174.85,
       "y": 2396.94,
-      "type": "target",
-      "move_mode": "jump",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "jump",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 21,
       "x": 2172.89,
       "y": 2398.74,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2),wait(0.3)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2),wait(0.3)",
+      "type": "target"
     },
     {
       "id": 22,
       "x": 2175.74,
       "y": 2395.32,
-      "type": "path",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2),wait(0.3)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2),wait(0.3)",
+      "type": "path"
     }
   ]
 }

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/沉玉谷/07-水晶块-沉玉谷-赤璋城垣(有战斗,精英200x4)-11个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/沉玉谷/07-水晶块-沉玉谷-赤璋城垣(有战斗,精英200x4)-11个.json
@@ -11,7 +11,11 @@
         "name": "火山",
         "links": "https://github.com/RRRR623"
       }
-    ]
+    ],
+    "tags": [],
+    "last_modified_time": 1755349570833,
+    "enable_monster_loot_split": false,
+    "map_match_method": ""
   },
   "positions": [
     {
@@ -173,10 +177,10 @@
       "id": 17,
       "x": 2233.6,
       "y": 1686.06,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 18,
@@ -324,6 +328,16 @@
     },
     {
       "id": 34,
+      "x": 1933.693359375,
+      "y": 1405.02685546875,
+      "action": "",
+      "move_mode": "jump",
+      "action_params": "",
+      "type": "path",
+      "locked": false
+    },
+    {
+      "id": 35,
       "x": 1933.13,
       "y": 1408.33,
       "action": "combat_script",
@@ -332,7 +346,7 @@
       "type": "target"
     },
     {
-      "id": 35,
+      "id": 36,
       "x": 1931.28,
       "y": 1408.48,
       "action": "combat_script",

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/02-水晶块-璃月-天衡山西南(有战斗,火免,精英200x1)-5个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/02-水晶块-璃月-天衡山西南(有战斗,火免,精英200x1)-5个.json
@@ -11,7 +11,11 @@
         "name": "火山",
         "links": "https://github.com/RRRR623"
       }
-    ]
+    ],
+    "tags": [],
+    "last_modified_time": 1755348907828,
+    "enable_monster_loot_split": false,
+    "map_match_method": ""
   },
   "positions": [
     {
@@ -63,19 +67,19 @@
       "id": 6,
       "x": 793.2,
       "y": -763.85,
-      "type": "path",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 7,
       "x": 791.12,
       "y": -772.63,
-      "type": "path",
-      "move_mode": "jump",
       "action": "fight",
+      "move_mode": "jump",
       "action_params": "",
+      "type": "path",
       "point_ext_params": {
         "misidentification": {
           "type": [
@@ -126,6 +130,15 @@
     },
     {
       "id": 12,
+      "x": 782.5439453125,
+      "y": -790.39599609375,
+      "type": "path",
+      "move_mode": "walk",
+      "action": "",
+      "action_params": ""
+    },
+    {
+      "id": 13,
       "x": 782.18,
       "y": -793.73,
       "action": "combat_script",
@@ -134,7 +147,7 @@
       "type": "target"
     },
     {
-      "id": 13,
+      "id": 14,
       "x": 776.16,
       "y": -794.7,
       "action": "combat_script",
@@ -143,7 +156,7 @@
       "type": "target"
     },
     {
-      "id": 14,
+      "id": 15,
       "x": 776.59,
       "y": -789.63,
       "action": "combat_script",
@@ -152,7 +165,7 @@
       "type": "target"
     },
     {
-      "id": 15,
+      "id": 16,
       "x": 782.9,
       "y": -789.58,
       "action": "combat_script",

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/04-水晶块-璃月-灵矩关南(有战斗,小怪)-3个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/04-水晶块-璃月-灵矩关南(有战斗,小怪)-3个.json
@@ -11,7 +11,11 @@
         "name": "火山",
         "links": "https://github.com/RRRR623"
       }
-    ]
+    ],
+    "tags": [],
+    "last_modified_time": 1755350329318,
+    "enable_monster_loot_split": false,
+    "map_match_method": ""
   },
   "positions": [
     {
@@ -83,10 +87,10 @@
       "id": 7,
       "x": 1092.86,
       "y": -652.76,
-      "type": "target",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "target"
     },
     {
       "id": 8,
@@ -119,15 +123,15 @@
       "id": 11,
       "x": 1086.72,
       "y": -663.5,
-      "type": "path",
-      "move_mode": "walk",
       "action": "",
-      "action_params": ""
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 12,
-      "x": 1090.63,
-      "y": -663.65,
+      "x": 1092.7724609375,
+      "y": -663.75830078125,
       "type": "path",
       "move_mode": "walk",
       "action": "",

--- a/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/24-水晶块-璃月-孤云阁南(定位不准，有战斗,精英200x1)-18个.json
+++ b/repo/pathing/矿物/水晶块/诺艾尔的提瓦特矿闻录@火山/璃月/24-水晶块-璃月-孤云阁南(定位不准，有战斗,精英200x1)-18个.json
@@ -11,296 +11,309 @@
         "name": "火山",
         "links": "https://github.com/RRRR623"
       }
-    ]
+    ],
+    "tags": [],
+    "last_modified_time": 1755348399468,
+    "enable_monster_loot_split": false,
+    "map_match_method": ""
   },
   "positions": [
     {
       "id": 1,
-      "action": "",
-      "move_mode": "walk",
-      "type": "teleport",
       "x": -963.35,
       "y": -288.94,
-      "action_params": ""
+      "action": "",
+      "move_mode": "walk",
+      "action_params": "",
+      "type": "teleport"
     },
     {
       "id": 2,
       "x": -907.64,
       "y": -274.26,
-      "type": "path",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 3,
       "x": -845.27,
       "y": -268.47,
-      "type": "target",
-      "move_mode": "dash",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "dash",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 4,
       "x": -848.98,
       "y": -280.33,
-      "type": "path",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 5,
       "x": -833.17,
       "y": -278.43,
-      "type": "path",
-      "move_mode": "dash",
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 6,
       "x": -831.82,
       "y": -275.9,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 7,
       "x": -831.6,
       "y": -272.64,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 8,
       "x": -835.37,
       "y": -271.42,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 9,
       "x": -835.96,
       "y": -272.18,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 10,
-      "x": -835.66,
-      "y": -276.28,
-      "type": "target",
+      "x": -833.787109375,
+      "y": -278.759765625,
+      "type": "path",
       "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "action": "",
+      "action_params": ""
     },
     {
       "id": 11,
-      "x": -791.25,
-      "y": -306.22,
-      "type": "path",
-      "move_mode": "dash",
-      "action": "",
-      "action_params": ""
+      "x": -835.66,
+      "y": -276.28,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 12,
-      "x": -794.35,
-      "y": -329.67,
-      "type": "path",
-      "move_mode": "dash",
+      "x": -791.25,
+      "y": -306.22,
       "action": "",
-      "action_params": ""
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 13,
-      "x": -777.43,
-      "y": -338.5,
-      "type": "target",
+      "x": -794.35,
+      "y": -329.67,
+      "action": "",
       "move_mode": "dash",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 14,
-      "x": -777.79,
-      "y": -335.54,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -777.43,
+      "y": -338.5,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "dash",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 15,
-      "x": -779.94,
-      "y": -334.9,
-      "type": "path",
+      "x": -777.79,
+      "y": -335.54,
+      "action": "combat_script",
       "move_mode": "walk",
-      "action": "",
-      "action_params": ""
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 16,
-      "x": -780.37,
-      "y": -331.46,
-      "type": "target",
+      "x": -779.94,
+      "y": -334.9,
+      "action": "",
       "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 17,
-      "x": -779.06,
-      "y": -344.17,
-      "type": "target",
-      "move_mode": "dash",
+      "x": -780.37,
+      "y": -331.46,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 18,
-      "x": -767.38,
-      "y": -347.32,
-      "type": "path",
+      "x": -779.06,
+      "y": -344.17,
+      "action": "combat_script",
       "move_mode": "dash",
-      "action": "",
-      "action_params": ""
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 19,
-      "x": -771.46,
-      "y": -351.51,
-      "type": "target",
-      "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "x": -767.38,
+      "y": -347.32,
+      "action": "",
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 20,
-      "x": -785.58,
-      "y": -346.91,
-      "type": "path",
-      "move_mode": "jump",
-      "action": "",
-      "action_params": ""
+      "x": -771.46,
+      "y": -351.51,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 21,
-      "x": -783.32,
-      "y": -348.78,
-      "type": "target",
-      "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "x": -785.58,
+      "y": -346.91,
+      "action": "",
+      "move_mode": "jump",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 22,
-      "x": -782.6,
-      "y": -351.83,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -783.32,
+      "y": -348.78,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 23,
-      "x": -781.15,
-      "y": -355.56,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -782.6,
+      "y": -351.83,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 24,
-      "x": -788.48,
-      "y": -361.19,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -781.15,
+      "y": -355.56,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 25,
-      "x": -817.75,
-      "y": -428.83,
-      "type": "target",
-      "move_mode": "dash",
+      "x": -788.48,
+      "y": -361.19,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 26,
-      "x": -816.07,
-      "y": -435.55,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -817.75,
+      "y": -428.83,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "dash",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 27,
-      "x": -822.58,
-      "y": -436.4,
-      "type": "path",
-      "move_mode": "dash",
-      "action": "",
-      "action_params": ""
+      "x": -816.07,
+      "y": -435.55,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 28,
-      "x": -821.28,
-      "y": -442.5,
-      "type": "target",
-      "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "x": -822.58,
+      "y": -436.4,
+      "action": "",
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
     },
     {
       "id": 29,
-      "x": -819.42,
-      "y": -447.41,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -821.28,
+      "y": -442.5,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 30,
-      "x": -824.72,
-      "y": -445.54,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -819.42,
+      "y": -447.41,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 31,
-      "x": -835.95,
-      "y": -466.1,
-      "type": "path",
-      "move_mode": "dash",
-      "action": "",
-      "action_params": ""
+      "x": -824.72,
+      "y": -445.54,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 32,
+      "x": -835.95,
+      "y": -466.1,
+      "action": "",
+      "move_mode": "dash",
+      "action_params": "",
+      "type": "path"
+    },
+    {
+      "id": 33,
       "x": -827.76,
       "y": -466.2,
-      "type": "path",
-      "move_mode": "dash",
       "action": "fight",
+      "move_mode": "dash",
       "action_params": "",
+      "type": "path",
       "point_ext_params": {
         "misidentification": {
           "type": [
@@ -314,76 +327,76 @@
       }
     },
     {
-      "id": 33,
+      "id": 34,
       "x": -813.78,
       "y": -473.81,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
-    },
-    {
-      "id": 34,
-      "x": -816.65,
-      "y": -464.31,
-      "type": "target",
       "move_mode": "walk",
-      "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 35,
-      "x": -811.45,
-      "y": -454.15,
-      "type": "target",
-      "move_mode": "jump",
+      "x": -816.65,
+      "y": -464.31,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 36,
-      "x": -815.0,
-      "y": -451.9,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -811.45,
+      "y": -454.15,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "jump",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 37,
-      "x": -815.72,
-      "y": -455.62,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -815,
+      "y": -451.9,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 38,
-      "x": -819.58,
-      "y": -456.69,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -815.72,
+      "y": -455.62,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 39,
-      "x": -822.16,
-      "y": -455.99,
-      "type": "target",
-      "move_mode": "walk",
+      "x": -819.58,
+      "y": -456.69,
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     },
     {
       "id": 40,
+      "x": -822.16,
+      "y": -455.99,
+      "action": "combat_script",
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
+    },
+    {
+      "id": 41,
       "x": -826.36,
       "y": -454.69,
-      "type": "target",
-      "move_mode": "walk",
       "action": "combat_script",
-      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)"
+      "move_mode": "walk",
+      "action_params": "诺艾尔 attack(0.2), attack(0.2),wait(0.3),attack(0.2),wait(1)",
+      "type": "target"
     }
   ]
 }


### PR DESCRIPTION
02-水晶块-璃月-天衡山西南 增加途径点，避免卡死
04-水晶块-璃月-灵矩关南 调整途径点位
24-水晶块-璃月-孤云阁南 增加途径点，避免错过挖矿点
04-水晶块-沉玉谷-灵濛山北 调整途径点位置，避免卡死
07-水晶块-沉玉谷-赤璋城垣 增加途径点，避免卡死

