### PR TITLE
repo/js/采集cd管理: 解决了在某些情况下可能生成非法record目录的问题

### DIFF
--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -122,7 +122,7 @@ if (!userSettings.infoFileName) {
         userSettings.pathGroup2CdType,
         userSettings.pathGroup3CdType,
         userSettings.otherPathGroupsCdTypes,
-    ].join(".");
+    ].join("_");
 }
 
 // 定义自定义函数 basename，用于获取文件名

--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -307,7 +307,7 @@ async function readFolder(folderPath, onlyJson) {
                     genshin.returnMainUi();
 
                     //切换到指定配队
-                    if (partyNamesArray[groupNumber - 1] !== "") {
+                    if (groupNumber - 1 < partyNamesArray.length && partyNamesArray[groupNumber - 1] !== "") { //队伍配置存在且不为空
                         await genshin.switchParty(partyNamesArray[groupNumber - 1])
                     }
 


### PR DESCRIPTION
当userSettings.infoFileName为空时，会用[userSettings.pathGroup1CdType, userSettings.pathGroup2CdType, userSettings.pathGroup3CdType, userSettings.otherPathGroupsCdTypes].join(".")作为infoFileName。这时，如果userSettings.otherPathGroupsCdTypes也为空，userSettings.pathGroup1CdType会以“.”结尾，并在后续被复制给subFolderName，而以“.”结尾的目录在Windows中非法，因此在加载或保存进度至record时会失败。
可行的解决方案可以是将.join(".")换成.join("_")（本pr采用的方案），或者去除末尾的“.“。