### PR TITLE
repo/js/采集cd管理: 解决了一个可能意外触发队伍切换，并传入非法队伍名称的问题

### DIFF
--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -307,7 +307,7 @@ async function readFolder(folderPath, onlyJson) {
                     genshin.returnMainUi();
 
                     //切换到指定配队
-                    if (partyNamesArray[groupNumber - 1] !== "") {
+                    if (groupNumber - 1 < partyNamesArray.length && partyNamesArray[groupNumber - 1] !== "") { //队伍配置存在且不为空
                         await genshin.switchParty(partyNamesArray[groupNumber - 1])
                     }
 


### PR DESCRIPTION
原先判断逻辑在partyNamesArray[groupNumber - 1]为undefined（索引越界）的时候仍会执行队伍切换，并且传入的队伍名称为undefined
新增了索引越界检查，避免了这种情况