### PR TITLE
repo/js/采集cd管理: 解决了一个skipHours可能意外包含0的问题

### DIFF
--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -337,7 +337,11 @@ async function readFolder(folderPath, onlyJson) {
 
                             // 新增校验：若当前时间的小时数和 skipTimeRanges 一致，则跳过任务
                             const currentHour = startTime.getHours(); // 获取当前时间的小时数
-                            const skipHours = userSettings.skipTimeRanges.split(';').map(Number); // 将 skipTimeRanges 转换为数字数组
+                            const skipHours = userSettings.skipTimeRanges
+                                .split(';')
+                                .map(s => s.trim())
+                                .filter(s => s !== '' && !isNaN(s)) // 过滤空字符串和非数字
+                                .map(Number); // 将 skipTimeRanges 转换为数字数组
                             if (skipHours.includes(currentHour)) {
                                 log.info(`当前时间的小时数为 ${currentHour}，在跳过时间范围内，跳过任务 ${entryName}`);
                                 continue; // 跳过当前任务


### PR DESCRIPTION
js中空字符转为Number会变成0，所以不填写不执行时间或者其包含多余分号时会导致skipHours里面有0

这个脚本刚刚用两三天就遇到这么多低级漏洞，代码质量堪忧。发布之前有好好做过测试吗？