### PR TITLE
适当修改部分紫晶块路线

### DIFF
--- a/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/A05-紫晶块-稻妻-鸣神岛-荒海-8~9个.json
+++ b/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/A05-紫晶块-稻妻-鸣神岛-荒海-8~9个.json
@@ -171,7 +171,7 @@
       "y": -2205.28,
       "action": "combat_script",
       "move_mode": "walk",
-      "action_params": "玛薇卡 wait(0.2),e(hold),wait(0.05),keydown(w),wait(0.01),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.2),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(0.2),e;",
+      "action_params": "玛薇卡 wait(0.2),e(hold),wait(0.05),keydown(w),wait(0.01),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.2),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.2),e;",
       "type": "orientation"
     },
     {

--- a/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/C01-紫晶块-稻妻-八酝島-名椎滩-西-2个.json
+++ b/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/C01-紫晶块-稻妻-八酝島-名椎滩-西-2个.json
@@ -43,7 +43,7 @@
       "y": -3533.1,
       "action": "combat_script",
       "move_mode": "walk",
-      "action_params": "玛薇卡 w(0.1),e(hold),wait(0.05),w(4.2),e;",
+      "action_params": "玛薇卡 w(0.1),e(hold),wait(0.05),w(4.2),e,wait(0.1),keypress(1),wait(0.1),keypress(2)",
       "type": "path"
     },
     {

--- a/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/C04-紫晶块-稻妻-八酝岛-绯木村-3个.json
+++ b/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/C04-紫晶块-稻妻-八酝岛-绯木村-3个.json
@@ -61,7 +61,7 @@
       "y": -3759.99,
       "action": "combat_script",
       "move_mode": "walk",
-      "action_params": "玛薇卡 w(0.2),e(hold),wait(0.05),keydown(w),wait(0.01),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.2),j,wait(0.1),j,wait(0.05),j,wait(0.5),e;",
+      "action_params": "玛薇卡 w(0.2),e(hold),wait(0.05),keydown(w),wait(0.01),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.2),j,wait(0.1),j,wait(0.05),j,wait(1.2),e;",
       "type": "orientation"
     },
     {

--- a/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/F04-紫晶块-稻妻-鹤观-菅名山-4个.json
+++ b/repo/pathing/矿物/紫晶块/紫晶块[大剑]@蜜柑魚/F04-紫晶块-稻妻-鹤观-菅名山-4个.json
@@ -52,7 +52,7 @@
       "y": -6406.19,
       "action": "combat_script",
       "move_mode": "walk",
-      "action_params": "玛薇卡 wait(0.2),e(hold),wait(0.05),keydown(w),wait(0.01),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(0.5),e;",
+      "action_params": "玛薇卡 wait(0.2),e(hold),wait(0.05),keydown(w),wait(0.01),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1.0),j,wait(0.15),j,wait(0.1),j,wait(0.01),j,wait(1),attack,wait(1.2),e",
       "type": "orientation"
     },
     {


### PR DESCRIPTION
A05, C04: 调整火神按E下车之前的等待间隔从0.2秒到1.2秒，避免在空中按E导致无法下车，导致后续赶路无法精确接近路径点，这适用于所有命座的火神
C01: 使用一种新的方法下车，避免按E时角色在水里而无法下车，这适用于所有命座的火神
F04: 赶路快接近终点时下落攻击并下车，避免冲刺过头摔下悬崖，这适用于所有命座的火神

文件中的所有修改分别使用0命、6命火神进行了测试，保证其兼容性。该修改已与脚本原作者沟通，并获认可。