### PR TITLE
fix: 修复在周一当天计算下周一逻辑错误导致本周进度被错误重置

### DIFF
--- a/repo/js/MiliastraExperienceAutomation/main.js
+++ b/repo/js/MiliastraExperienceAutomation/main.js
@@ -136,7 +136,7 @@ const getNextMonday4AM = () => {
   if (currentDay === 1 && now.getHours() < 4) {
     daysUntilMonday = 0;
   } else {
-    daysUntilMonday = (8 - currentDay) % 7;
+    daysUntilMonday = 8 - currentDay;
   }
   result.setDate(now.getDate() + daysUntilMonday);
   return result;

--- a/repo/js/MiliastraExperienceAutomation/manifest.json
+++ b/repo/js/MiliastraExperienceAutomation/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "千星奇域每周刷取经验值",
-  "version": "0.2",
+  "version": "0.3",
   "bgi_version": "0.52.0",
   "description": "千星奇域每周刷取经验值",
   "authors": [


### PR DESCRIPTION
修复**仅当在周一当天使用脚本时**，由于错误地计算下周一的结果为当日4点，导致如果在周一当日重复执行此脚本时会重置本周已执行的进度。~~AI编码提示害人不浅~~