### PR TITLE
为锄地一条龙增加了路径黑名单功能

### DIFF
--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -23,6 +23,14 @@ const timeMove = (+settings.timeMove || 1000);
 let warnMessage = [];
 let blacklist = [];
 let blacklistSet = new Set();
+let blacklistedPathings = [];
+if (settings.blacklistedPathings) {
+    blacklistedPathings = settings.blacklistedPathings.split('；').map(s => s.trim()).filter(s => s.length > 0);
+    log.info(`已加载路径黑名单，共${blacklistedPathings.length}条`);
+} else {
+    blacklistedPathings = [];
+}
+
 let state;
 const accountName = settings.accountName || "默认账户";
 let pathings;
@@ -166,6 +174,10 @@ async function processPathings() {
 
     // 读取路径文件夹中的所有文件
     let pathings = await readFolder("pathing", true);
+    // 过滤掉包含路径黑名单中任一路径名片段的路径
+    pathings = pathings.filter(pathing => {
+        return !blacklistedPathings.some(blacklistedPathing => pathing.fileName.includes(blacklistedPathing));
+    });
 
     //加载路线cd信息
     await initializeCdTime(pathings, accountName);

--- a/repo/js/AutoHoeingOneDragon/settings.json
+++ b/repo/js/AutoHoeingOneDragon/settings.json
@@ -172,5 +172,10 @@
     "name": "tagsForGroup10",
     "type": "input-text",
     "label": "路径组十要【选择】的标签"
+  },
+  {
+    "name": "blacklistedPathings",
+    "type": "input-text",
+    "label": "路径黑名单，请填写路径文件名，可只填写文件名的一部分\n多个路径命用【中文分号】分隔\n这些路径将不会被选择运行"
   }
 ]


### PR DESCRIPTION
简单在路径处理流程中添加了根据自定义设置中的路径黑名单预先排除指定的一条或多条路径的功能，并在设置中相应增加了设置项。