### PR TITLE
解決雙倍好感腳本會點擊好友查看千星奇遇資料而非申請造訪塵歌壺 

### DIFF
--- a/repo/js/使用历练点完成每日委托/main.js
+++ b/repo/js/使用历练点完成每日委托/main.js
@@ -380,7 +380,7 @@ const adventurePath = settings.adventurePath || '蒙德'; // 若未定义，用�
         }
 
         let y_avatar = 178; //好友头像按钮起始Y坐标
-        let y_request = 245; //申请造访按钮起始Y坐标
+        let y_request = 310; //申请造访按钮起始Y坐标
         const x_avatar = 208;
         const x_request = 460;
         const avatar_increment = 125; //两按钮相隔坐标
@@ -407,7 +407,7 @@ const adventurePath = settings.adventurePath || '蒙德'; // 若未定义，用�
                 await sleep(750);
             } else {
                 // 奇数索引，递增 y_request
-                if (request_count < 2) {
+                if (request_count < 1) {
                     // 前 3 位好友递增 249
                     y_request += request_increment;
                 } else {

--- a/repo/js/使用历练点完成每日委托/manifest.json
+++ b/repo/js/使用历练点完成每日委托/manifest.json
@@ -1,22 +1,18 @@
 {
   "manifest_version": 1,
   "name": "使用历练点完成每日委托",
-  "version": "2",
+  "version": "2.0.1",
   "bgi_version": "0.44.1",
   "description": "使用历练点完成每日委托：\n支持进入好友尘歌壶，使用历练点领取双倍好感(队伍中小于等于两人时，能使队伍中两人获得双倍好感)\n支持进入好友尘歌壶后，让指定位置角色离队\n能指定星期几执行，星期几不执行\n前往冒险家协会领取奖励",
-  "tags": [
-    "历练点",
-    "每日委托"
-  ],
   "authors": [
     {
       "name": "起个名字好难的喵",
       "links": "https://github.com/MisakaAldrich"
     },
     {
-      "name": "蜜柑魚",
-      "links": "https://github.com/this-Fish"
-    }
+        "name": "蜜柑魚",
+        "links": "https://github.com/this-Fish"
+      }
   ],
   "settings_ui": "settings.json",
   "main": "main.js"


### PR DESCRIPTION
[bug] 雙倍好感腳本問題 https://github.com/babalae/bettergi-scripts-list/issues/2373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新增功能**
  * 重新启用并完善了双倍友谊遇遇点流程功能

* **Bug 修复**
  * 调整了造访仙灵峰境的按钮触发位置，改进交互体验

* **更新**
  * 双倍友谊遇遇点脚本版本更新至 2.1.4
  * 历练点每日委托脚本版本更新至 2.0.1，优化了清单信息

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->