### PR TITLE
fix

### DIFF
--- a/repo/pathing/敌人与魔物/史莱姆/史莱姆速刷.json
+++ b/repo/pathing/敌人与魔物/史莱姆/史莱姆速刷.json
@@ -4,7 +4,7 @@
     "type": "collect",
     "version": "1.0",
     "description": "",
-    "bgi_version": "0.42.0",
+    "bgi_version": "0.52.0",
     "authors": [
       {
         "name": "爱凑热闹"


### PR DESCRIPTION
修复史莱姆刷取路线：

1. 修复跳崖暴毙。
2. 删除不正确的路线（跳崖划水）。
