### PR TITLE
feat(pathing): 添加深黯钓客系列路径配置文件

### DIFF
--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-厄布拉神柱-01.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-厄布拉神柱-01.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "authors": [
       {
@@ -6,7 +6,7 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768438175955,
@@ -24,8 +24,8 @@
       "id": 1,
       "move_mode": "walk",
       "type": "teleport",
-      "x": 9774.3779296875,
-      "y": 5530.5712890625
+      "x": 9774.3779,
+      "y": 5530.5713
     },
     {
       "action": "fight",
@@ -34,8 +34,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9770.490234375,
-      "y": 5604.2705078125
+      "x": 9770.4902,
+      "y": 5604.2705
     },
     {
       "action": "pick_up_collect",
@@ -44,8 +44,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9770.490234375,
-      "y": 5604.2705078125
+      "x": 9770.4902,
+      "y": 5604.2705
     },
     {
       "action": "pick_around",
@@ -53,8 +53,8 @@
       "id": 4,
       "move_mode": "walk",
       "type": "path",
-      "x": 9770.490234375,
-      "y": 5604.2705078125
+      "x": 9770.4902,
+      "y": 5604.2705
     }
   ]
 }

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-噩影泽地-01.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-噩影泽地-01.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "authors": [
       {
@@ -6,7 +6,7 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768438172670,
@@ -24,8 +24,8 @@
       "id": 1,
       "move_mode": "walk",
       "type": "teleport",
-      "x": 9351.3740234375,
-      "y": 5442.234375
+      "x": 9351.374,
+      "y": 5442.2344
     },
     {
       "action": "",
@@ -33,8 +33,8 @@
       "id": 2,
       "move_mode": "walk",
       "type": "path",
-      "x": 9403.2587890625,
-      "y": 5459.3447265625
+      "x": 9403.2588,
+      "y": 5459.3447
     },
     {
       "action": "fight",
@@ -43,8 +43,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9420.677734375,
-      "y": 5483.47119140625
+      "x": 9420.6777,
+      "y": 5483.4712
     },
     {
       "action": "pick_up_collect",
@@ -53,8 +53,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9420.677734375,
-      "y": 5483.47119140625
+      "x": 9420.6777,
+      "y": 5483.4712
     },
     {
       "action": "pick_around",
@@ -62,8 +62,8 @@
       "id": 5,
       "move_mode": "walk",
       "type": "path",
-      "x": 9420.677734375,
-      "y": 5483.47119140625
+      "x": 9420.6777,
+      "y": 5483.4712
     }
   ]
 }

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-01.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-01.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "authors": [
       {
@@ -6,7 +6,7 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436838308,
@@ -25,8 +25,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "teleport",
-      "x": 10286.666015625,
-      "y": 6356.35498046875
+      "x": 10286.666,
+      "y": 6356.355
     },
     {
       "action": "stop_flying",
@@ -35,8 +35,8 @@
       "locked": false,
       "move_mode": "fly",
       "type": "path",
-      "x": 10259.017578125,
-      "y": 6333.9619140625
+      "x": 10259.0176,
+      "y": 6333.9619
     },
     {
       "action": "fight",
@@ -45,8 +45,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10259.017578125,
-      "y": 6333.9619140625
+      "x": 10259.0176,
+      "y": 6333.9619
     },
     {
       "action": "pick_up_collect",
@@ -55,8 +55,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10259.017578125,
-      "y": 6333.9619140625
+      "x": 10259.0176,
+      "y": 6333.9619
     },
     {
       "action": "pick_around",
@@ -65,8 +65,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10259.017578125,
-      "y": 6333.9619140625
+      "x": 10259.0176,
+      "y": 6333.9619
     },
     {
       "action": "",
@@ -75,8 +75,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10273.396484375,
-      "y": 6315.822265625
+      "x": 10273.3965,
+      "y": 6315.8223
     }
   ]
 }

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-02.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-02.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "authors": [
       {
@@ -6,7 +6,7 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436855887,
@@ -25,8 +25,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "teleport",
-      "x": 10101.603515625,
-      "y": 6343.75146484375
+      "x": 10101.6035,
+      "y": 6343.7515
     },
     {
       "action": "",
@@ -35,8 +35,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10090.2919921875,
-      "y": 6331.35107421875
+      "x": 10090.292,
+      "y": 6331.3511
     },
     {
       "action": "fight",
@@ -45,8 +45,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10085.48828125,
-      "y": 6326.89453125
+      "x": 10085.4883,
+      "y": 6326.8945
     },
     {
       "action": "pick_up_collect",
@@ -55,8 +55,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10085.48828125,
-      "y": 6326.89453125
+      "x": 10085.4883,
+      "y": 6326.8945
     },
     {
       "action": "pick_around",
@@ -65,8 +65,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10085.48828125,
-      "y": 6326.89453125
+      "x": 10085.4883,
+      "y": 6326.8945
     },
     {
       "action": "",
@@ -75,8 +75,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10087.5078125,
-      "y": 6300.7294921875
+      "x": 10087.5078,
+      "y": 6300.7295
     },
     {
       "action": "fight",
@@ -85,8 +85,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10091.783203125,
-      "y": 6274.7119140625
+      "x": 10091.7832,
+      "y": 6274.7119
     },
     {
       "action": "pick_up_collect",
@@ -95,8 +95,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10091.783203125,
-      "y": 6274.7119140625
+      "x": 10091.7832,
+      "y": 6274.7119
     },
     {
       "action": "pick_around",
@@ -105,8 +105,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10091.783203125,
-      "y": 6274.7119140625
+      "x": 10091.7832,
+      "y": 6274.7119
     },
     {
       "action": "",
@@ -115,8 +115,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10099.013671875,
-      "y": 6283.34033203125
+      "x": 10099.0137,
+      "y": 6283.3403
     },
     {
       "action": "",
@@ -125,8 +125,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10095.1298828125,
-      "y": 6263.1328125
+      "x": 10095.1299,
+      "y": 6263.1328
     },
     {
       "action": "",
@@ -135,8 +135,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10107.787109375,
-      "y": 6265.91552734375
+      "x": 10107.7871,
+      "y": 6265.9155
     },
     {
       "action": "fight",
@@ -145,8 +145,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10130.953125,
-      "y": 6303.19921875
+      "x": 10130.9531,
+      "y": 6303.1992
     },
     {
       "action": "pick_up_collect",
@@ -155,8 +155,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10130.953125,
-      "y": 6303.19921875
+      "x": 10130.9531,
+      "y": 6303.1992
     },
     {
       "action": "pick_around",
@@ -165,8 +165,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10130.953125,
-      "y": 6303.19921875
+      "x": 10130.9531,
+      "y": 6303.1992
     },
     {
       "action": "",
@@ -176,7 +176,7 @@
       "move_mode": "walk",
       "type": "path",
       "x": 10150.1875,
-      "y": 6326.416015625
+      "y": 6326.416
     },
     {
       "action": "",
@@ -185,8 +185,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10146.935546875,
-      "y": 6335.291015625
+      "x": 10146.9355,
+      "y": 6335.291
     },
     {
       "action": "",
@@ -195,8 +195,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10158.3330078125,
-      "y": 6335.53466796875
+      "x": 10158.333,
+      "y": 6335.5347
     },
     {
       "action": "",
@@ -205,8 +205,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10164.009765625,
-      "y": 6329.98876953125
+      "x": 10164.0098,
+      "y": 6329.9888
     },
     {
       "action": "fight",
@@ -215,8 +215,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10195.083984375,
-      "y": 6323.2822265625
+      "x": 10195.084,
+      "y": 6323.2822
     },
     {
       "action": "pick_up_collect",
@@ -225,8 +225,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10195.083984375,
-      "y": 6323.2822265625
+      "x": 10195.084,
+      "y": 6323.2822
     },
     {
       "action": "pick_around",
@@ -235,8 +235,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10195.083984375,
-      "y": 6323.2822265625
+      "x": 10195.084,
+      "y": 6323.2822
     },
     {
       "action": "",
@@ -245,8 +245,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10204.6435546875,
-      "y": 6319.4990234375
+      "x": 10204.6436,
+      "y": 6319.499
     }
   ]
 }

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-03.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-03.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "authors": [
       {
@@ -6,7 +6,7 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436867897,
@@ -25,8 +25,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "teleport",
-      "x": 10101.634765625,
-      "y": 6343.76708984375
+      "x": 10101.6348,
+      "y": 6343.7671
     },
     {
       "action": "",
@@ -35,8 +35,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10080.8759765625,
-      "y": 6329.021484375
+      "x": 10080.876,
+      "y": 6329.0215
     },
     {
       "action": "",
@@ -45,8 +45,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 10018.1923828125,
-      "y": 6363.44873046875
+      "x": 10018.1924,
+      "y": 6363.4487
     },
     {
       "action": "fight",
@@ -55,8 +55,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9988.9755859375,
-      "y": 6369.64990234375
+      "x": 9988.9756,
+      "y": 6369.6499
     },
     {
       "action": "pick_up_collect",
@@ -65,8 +65,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9988.9755859375,
-      "y": 6369.64990234375
+      "x": 9988.9756,
+      "y": 6369.6499
     },
     {
       "action": "pick_around",
@@ -75,8 +75,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9988.9755859375,
-      "y": 6369.64990234375
+      "x": 9988.9756,
+      "y": 6369.6499
     },
     {
       "action": "",
@@ -86,7 +86,7 @@
       "move_mode": "walk",
       "type": "path",
       "x": 9984.125,
-      "y": 6366.47607421875
+      "y": 6366.4761
     }
   ]
 }

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-04.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-04.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "info": {
     "authors": [
       {
@@ -6,7 +6,7 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436880277,
@@ -25,8 +25,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "teleport",
-      "x": 9780.400390625,
-      "y": 6212.5244140625
+      "x": 9780.4004,
+      "y": 6212.5244
     },
     {
       "action": "",
@@ -35,7 +35,7 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9748.9609375,
+      "x": 9748.9609,
       "y": 6258.5625
     },
     {
@@ -45,8 +45,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9697.4306640625,
-      "y": 6256.9931640625
+      "x": 9697.4307,
+      "y": 6256.9932
     },
     {
       "action": "stop_flying",
@@ -55,8 +55,8 @@
       "locked": false,
       "move_mode": "fly",
       "type": "path",
-      "x": 9638.37109375,
-      "y": 6303.0654296875
+      "x": 9638.3711,
+      "y": 6303.0654
     },
     {
       "action": "fight",
@@ -65,8 +65,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9610.08984375,
-      "y": 6348.53662109375
+      "x": 9610.0898,
+      "y": 6348.5366
     },
     {
       "action": "pick_up_collect",
@@ -75,8 +75,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9610.08984375,
-      "y": 6348.53662109375
+      "x": 9610.0898,
+      "y": 6348.5366
     },
     {
       "action": "pick_around",
@@ -85,8 +85,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9610.08984375,
-      "y": 6348.53662109375
+      "x": 9610.0898,
+      "y": 6348.5366
     },
     {
       "action": "",
@@ -95,8 +95,8 @@
       "locked": false,
       "move_mode": "walk",
       "type": "path",
-      "x": 9598.2255859375,
-      "y": 6360.7041015625
+      "x": 9598.2256,
+      "y": 6360.7041
     }
   ]
 }


### PR DESCRIPTION
- 新增厄布拉神柱位置的深黯钓客路径配置
- 新增噩影泽地位置的深黯钓客路径配置
- 新增苦壑崖四个不同位置的深黯钓客路径配置
- 所有配置均支持收集类型任务并包含战斗和拾取动作
- 每个配置文件都包含了完整的坐标路径和行动指令