### PR TITLE
chore(config): 更新深黯钓客路径配置文件

### DIFF
--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-厄布拉神柱-01.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-厄布拉神柱-01.json
@@ -6,11 +6,11 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.52.0",
+    "bgi_version": "0.54.3",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768438175955,
-    "map_match_method": "",
+    "map_match_method": "SIFT",
     "map_name": "Teyvat",
     "name": "深黯钓客-厄布拉神柱-01",
     "tags": [],

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-噩影泽地-01.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-噩影泽地-01.json
@@ -6,11 +6,11 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.52.0",
+    "bgi_version": "0.54.3",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768438172670,
-    "map_match_method": "",
+    "map_match_method": "SIFT",
     "map_name": "Teyvat",
     "name": "深黯钓客-噩影泽地-01",
     "tags": [],

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-01.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-01.json
@@ -6,11 +6,11 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.52.0",
+    "bgi_version": "0.54.3",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436838308,
-    "map_match_method": "",
+    "map_match_method": "SIFT",
     "map_name": "Teyvat",
     "name": "深黯钓客-苦壑崖-01",
     "tags": [],

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-02.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-02.json
@@ -6,11 +6,11 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.52.0",
+    "bgi_version": "0.54.3",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436855887,
-    "map_match_method": "",
+    "map_match_method": "SIFT",
     "map_name": "Teyvat",
     "name": "深黯钓客-苦壑崖-02",
     "tags": [],

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-03.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-03.json
@@ -6,11 +6,11 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.52.0",
+    "bgi_version": "0.54.3",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436867897,
-    "map_match_method": "",
+    "map_match_method": "SIFT",
     "map_name": "Teyvat",
     "name": "深黯钓客-苦壑崖-03",
     "tags": [],

--- a/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-04.json
+++ b/repo/pathing/敌人与魔物/深黯钓客/深黯钓客-苦壑崖-04.json
@@ -6,11 +6,11 @@
         "name": "云端客"
       }
     ],
-    "bgi_version": "0.52.0",
+    "bgi_version": "0.54.3",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1768436880277,
-    "map_match_method": "",
+    "map_match_method": "SIFT",
     "map_name": "Teyvat",
     "name": "深黯钓客-苦壑崖-04",
     "tags": [],


### PR DESCRIPTION
- 将 bgi_version 从 0.52.0 更新到 0.54.3
- 为所有深黯钓客配置添加 SIFT 地图匹配方法
- 更新厄布拉神柱、噩影泽地和苦壑崖等多个位置的配置
- 统一所有相关路径点的地图匹配算法设置