### PR TITLE
适配新版本AutoSkip的改动

### DIFF
--- a/repo/js/使用历练点完成每日委托/main.js
+++ b/repo/js/使用历练点完成每日委托/main.js
@@ -766,7 +766,7 @@ const adventurePath = settings.adventurePath || '蒙德'; // 若未定义，用�
         await keyPress("f");
         await sleep(1000);
         // 利用自動劇情領奬
-        dispatcher.addTimer(new RealtimeTimer("AutoSkip", { "forceInteraction": true }));
+        dispatcher.addTimer(new RealtimeTimer("AutoSkip"));
         await sleep(10000);
         await genshin.returnMainUi();
         await sleep(1000);


### PR DESCRIPTION
本身是错误用法，BGI老版本忽略了这个参数，新版本增加了参数检查，这里会稳定报错
<img width="1715" height="595" alt="image" src="https://github.com/user-attachments/assets/aab7b2b5-7bb1-4e32-9a95-abb1b6b9e05a" />
