### PR TITLE
fix(js): 修复点击跳过奇域等级提升页面失败

### DIFF
--- a/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
@@ -35,7 +35,7 @@ const findCloseDialog = () => {
 };
 //! 通用：点击空白处区域继续位置
 const clickToContinue = () => {
-  click(900, 1050);
+  click(960, 1070);
 };
 //! 查找UID文本
 const findUidText = () => {
@@ -185,10 +185,6 @@ const findStageEscBtn = () => {
 const findExitStageBtn = () => {
   return findTextWithinBounds("中断挑战", 576, 324, 768, 432);
 };
-//! 关卡：查找奇域等级提升页面
-const findSkipLevelUpMsg = () => {
-  return findTextWithinBounds("空白处", 610, 950, 700, 60, { contains: true });
-};
 //! 退出：查找返回提瓦特按钮
 const findGotTeyvatBtn = () => {
   return findTextWithinBounds("返回", 1500, 0, 300, 95, { contains: true });
@@ -259,7 +255,6 @@ export {
   findSearchWonderlandBtn,
   findSearchWonderlandInput,
   findSearchWonderlandThrottleMsg,
-  findSkipLevelUpMsg,
   findStageEscBtn,
   findUidText,
 };

--- a/repo/js/MiliastraExperiencePlayback/libs/modules/stage.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/modules/stage.js
@@ -13,7 +13,6 @@ import {
   findCloseDialog,
   findExitStageBtn,
   findPrepareMsg,
-  findSkipLevelUpMsg,
   findStageEscBtn,
 } from "../constants/regions.js";
 import { isInLobby } from "./lobby.js";
@@ -111,7 +110,7 @@ const exitStageToLobby = async () => {
       isInLobby,
       async () => {
         //! 跳过奇域等级提升页面（奇域等级每逢11、21、31、41级时出现加星页面）
-        if (findSkipLevelUpMsg()) clickToContinue();
+        clickToContinue();
         //! 点击底部 “返回大厅” 按钮
         findBottomBtnText("返回大厅")?.click();
       },

--- a/repo/js/MiliastraExperiencePlayback/manifest.json
+++ b/repo/js/MiliastraExperiencePlayback/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "千星奇域·每周经验刷取(回放通关版)",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "bgi_version": "0.54.0",
   "description": "千星奇域·每周经验刷取(回放通关版)",
   "authors": [


### PR DESCRIPTION
修复问题：
  新版本奇域等级提升页面的`点击空白处继续`会被OCR识别成`点击空自处继续`，导致结算失败。
  现改为无条件点击空白处（不再发现`点击空白处继续`文本后才点击），同时空白处改为保守的位置防止乱点击。