### PR TITLE
js: CD-Aware-AutoGather: 修复两个corner case

### DIFF
--- a/repo/js/CD-Aware-AutoGather/README.md
+++ b/repo/js/CD-Aware-AutoGather/README.md
@@ -9,7 +9,7 @@
 - 可设置一个或多个不运行的时间段
 - 采集过程自动切换合适的队伍
 
-**若脚本有问题，可[点击此处进行反馈](https://github.com/babalae/bettergi-scripts-list/issues/new?template=bug_report.yml&script-name=CD-Aware-AutoGather:2.1.0&additional-info=保留此行以便通知作者:%20@Patrick-Ze%0A%0A---%0A)**
+**若脚本有问题，可[点击此处进行反馈](https://github.com/babalae/bettergi-scripts-list/issues/new?template=bug_report.yml&script-name=CD-Aware-AutoGather:2.2.0&additional-info=保留此行以便通知作者:%20@Patrick-Ze%0A%0A---%0A)**
 
 # 使用前准备
 

--- a/repo/js/CD-Aware-AutoGather/lib/inventory.js
+++ b/repo/js/CD-Aware-AutoGather/lib/inventory.js
@@ -132,7 +132,8 @@ const csvText = `物品,刷新机制,背包分类
 烛伞蘑菇,每天0点,食物
 `
 
-const renameMap = { "晶蝶": "晶核", "「冷鲜肉」": "冷鲜肉", "白铁矿": "白铁块", "铁矿": "铁块" };
+// 材料文件夹名: 背包物品名（准确地说是API返回的材料名）
+const renameMap = { "晶蝶": "晶核", "「冷鲜肉」": "冷鲜肉"};
 
 const supportFile = "native_supported.json";
 const materialMetadata = {};

--- a/repo/js/CD-Aware-AutoGather/lib/lib.js
+++ b/repo/js/CD-Aware-AutoGather/lib/lib.js
@@ -736,6 +736,9 @@ async function waitTpFinish(timeout = 30000) {
 }
 
 function calculateDistance(point1, point2) {
+    if (point1 === null || point2 === null) {
+        return null;
+    }
     const deltaX = point1.x - point2.x;
     const deltaY = point1.y - point2.y;
     const distance = Math.sqrt(Math.pow(deltaX, 2) + Math.pow(deltaY, 2));

--- a/repo/js/CD-Aware-AutoGather/manifest.json
+++ b/repo/js/CD-Aware-AutoGather/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "name": "带CD管理和目标设定的自动采集",
   "_version_note": "更新版本号时请一并更新README的问题反馈链接中的版本号",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "bgi_version": "0.55.0",
   "description": "自动同步你通过BetterGI订阅的地图追踪任务，执行采集任务，并管理材料采集目标和刷新时间。\n支持联机模式采集和多账号记录。\n首次使用前请先简单阅读说明",
   "authors": [


### PR DESCRIPTION
Fixes #2855, Fixes #2861: 新地图无法获取坐标时改用时间差判断是否更新CD
Fixes #2860: 修复背包物品与API物品名不匹配时脚本异常终止的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 版本 2.2.0 发布

* **Bug 修复**
  * 修复了路径任务执行后位置数据缺失导致的异常
  * 增强了距离计算功能的容错能力

* **杂项**
  * 版本号升级至 2.2.0
  * 优化物品名称映射配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->