### PR TITLE
js：锄地一条龙2.3.0

### DIFF
--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -1148,7 +1148,13 @@ async function runPath(fullPath, map_name, pm, pe) {
 
         if (pickup_Mode.includes("模板匹配")) {
             while (state.running) {
-                await sleep(1500);
+                let sleepTimes = 0;
+                while (state.running && sleepTimes < 30) {
+                    await sleep(50);
+                    sleepTimes++;
+                }
+                if (!state.running) break;
+
                 if (await checkItemFull()) {
                     const TEXT_X = 560, TEXT_Y = 450, TEXT_W = 1360 - 560, TEXT_H = 620 - 450;
                     let ocrText = null;
@@ -1396,7 +1402,13 @@ async function dumper(pathFilePath, map_name) {
         if (!disableDumper) {
             while (state.running) {
                 //log.info("调试-泥头车循环");
-                await sleep(501);
+                let sleepTimes = 0;
+                while (state.running && sleepTimes < 10) {
+                    await sleep(50);
+                    sleepTimes++;
+                }
+                if (!state.running) break;
+                await sleep(1);
                 if (await isMainUI() && !await findAndClick(flyingRo, false, 2, 3)) {
                     //log.info("调试-获取坐标");
                     //在主界面才尝试获取坐标

--- a/repo/js/AutoHoeingOneDragon/manifest.json
+++ b/repo/js/AutoHoeingOneDragon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "锄地一条龙",
-  "version": "2.2.10",
+  "version": "2.3.0",
   "description": "一站式解决自动化锄地，支持只拾取狗粮，请仔细阅读README.md后使用",
   "authors": [
     {


### PR DESCRIPTION
优化长延时，预期降低路线切换时相关部分的延时（770ms→33.3ms）