### PR TITLE
删除重复的欧洛伦脚本

### DIFF
--- a/repo/combat/万能战斗策略（萌新推荐）.txt
+++ b/repo/combat/万能战斗策略（萌新推荐）.txt
@@ -73,7 +73,6 @@
 欧洛伦 e, attack(0.3), keypress(q), wait(0.2), attack(0.3), keypress(q), wait(0.2), attack(0.3), keypress(q), wait(0.3)
 雷电将军 e, attack(0.22), keypress(q), wait(0.1), keypress(q), attack(0.2), keypress(q), attack(0.2)
 久岐忍 e, wait(0.2), keypress(q), attack(0.15), keypress(q), e
-欧洛伦 e, attack(0.3), keypress(q), wait(0.2), attack(0.3), keypress(q), wait(0.2), dash(0.1), attack(0.3), keypress(q), wait(0.3)
 瓦雷莎 e, attack(1.25), wait(0.45), s(0.4), click(middle), e, attack(1.25), wait(0.3), keypress(q), wait(0.45)
 
 
@@ -117,4 +116,5 @@
 // （满命转圈喷5.5秒）希格雯 e(hold), keypress(q), wait(0.2), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1), moveby(300, 0), wait(0.1)
 
 菲林斯 attack(0.2), click(middle), ready, keydown(w), e, attack(0.3), keyup(w), ready, keydown(s), e, keypress(q), attack(0.3), keyup(s), ready, keydown(w), attack(0.33), keyup(w), ready, e, keypress(q), attack(0.33), keydown(s), e, attack(0.33), keyup(s), ready, keypress(q), attack(0.2), keydown(w), attack(0.2), keyup(w), ready, keydown(s), e, attack(0.2), keyup(s), ready, keypress(e), attack(0.25), e, keypress(q), ready, keydown(w), e, attack(0.3), keyup(w), ready, keydown(s), e, keypress(q), attack(0.3), keyup(s), ready, keydown(w), attack(0.33), keyup(w), ready, e, keypress(q), attack(0.33), keydown(s), e, attack(0.33), keyup(s), ready, attack(0.2), keypress(q), ready
+
 


### PR DESCRIPTION
现在轮到欧洛仑时会有大量的多余动作，长时间滞留场上。打开策略发现他的脚本赘余一整行。