### PR TITLE
批量讨伐角色养成材料BOSS 0.7.1

### DIFF
--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/兆载永劫龙兽前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/兆载永劫龙兽前往.json
@@ -1,11 +1,11 @@
 {
   "info": {
     "authors": [],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1755828864835,
-    "map_match_method": "",
     "map_name": "Teyvat",
     "name": "未命名路径",
     "tags": [],

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/千年珍珠骏麟前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/千年珍珠骏麟前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753791394637,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/半永恒统辖矩阵前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/半永恒统辖矩阵前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753788953823,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/古岩龙蜥前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/古岩龙蜥前往.json
@@ -5,7 +5,8 @@
     "author": "柒叶子",
     "version": "1.0",
     "description": "前往古岩龙蜥",
-    "bgi_version": "0.42.3"
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch"
   },
   "positions": [
     {

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/守望者·堕天前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/守望者·堕天前往.json
@@ -6,7 +6,7 @@
         "name": "DarkFlameMaster"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1775791356948,

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/急冻树前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/急冻树前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753707716845,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/恒常机关阵列前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/恒常机关阵列前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753787243395,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/掣电树前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/掣电树前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753788008539,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/无相之水前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/无相之水前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753787792567,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/无相之草前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/无相之草前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753788793031,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/水形幻人前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/水形幻人前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753791583765,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/深罪浸礼者前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/深罪浸礼者前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753789336063,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/深邃摹结株前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/深邃摹结株前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792527051,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/深黯魇语之主前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/深黯魇语之主前往.json
@@ -6,7 +6,7 @@
         "name": "DarkFlameMaster"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1775700388310,

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/灵觉隐修的迷者前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/灵觉隐修的迷者前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792615054,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/熔岩辉龙像前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/熔岩辉龙像前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792755970,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/爆炎树前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/爆炎树前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753711249019,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/秘源机兵·构型械前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/秘源机兵·构型械前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792234740,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/翠翎恐蕈前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/翠翎恐蕈前往.json
@@ -11,11 +11,11 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753788482153,
-    "enable_monster_loot_split": false,
-    "map_match_method": "TemplateMatch"
+    "enable_monster_loot_split": false
   },
   "positions": [
     {

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/蕴光月守宫强制传送.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/蕴光月守宫强制传送.json
@@ -6,7 +6,7 @@
         "name": "DarkFlameMaster"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1775787047367,

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/蕴光月幻蝶强制传送.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/蕴光月幻蝶强制传送.json
@@ -6,7 +6,7 @@
         "name": "少年"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1775793118383,

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/贪食匿叶龙山王前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/贪食匿叶龙山王前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792348393,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/超重型陆巡舰·机动战垒强制传送.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/超重型陆巡舰·机动战垒强制传送.json
@@ -6,11 +6,11 @@
         "name": "DarkFlameMaster"
       }
     ],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1775791925697,
-    "map_match_method": "",
     "map_name": "Teyvat",
     "name": "超重型陆巡舰·机动战垒",
     "tags": [],

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/遗迹巨蛇前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/遗迹巨蛇前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "TheChasm",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753793052904,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/重拳出击鸭前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/重拳出击鸭前往.json
@@ -1,11 +1,11 @@
 {
   "info": {
     "authors": [],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "SIFT",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1763000407374,
-    "map_match_method": "",
     "map_name": "Teyvat",
     "name": "重拳出击鸭",
     "tags": [],

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/重拳出击鸭战斗后快速前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/重拳出击鸭战斗后快速前往.json
@@ -1,11 +1,11 @@
 {
   "info": {
     "authors": [],
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "SIFT",
     "description": "",
     "enable_monster_loot_split": false,
     "last_modified_time": 1763000508226,
-    "map_match_method": "",
     "map_name": "Teyvat",
     "name": "重拳出击鸭-打完返回",
     "tags": [],

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/金焰绒翼龙暴君前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/金焰绒翼龙暴君前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792463678,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/铁甲熔火帝皇前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/铁甲熔火帝皇前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792049126,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/隐山猊兽前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/隐山猊兽前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753787074751,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/风蚀沙虫前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/风蚀沙虫前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753789042822,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/魔像督军前往.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/assets/Pathing/魔像督军前往.json
@@ -11,7 +11,8 @@
     "version": "1.0",
     "description": "",
     "map_name": "Teyvat",
-    "bgi_version": "0.45.0",
+    "bgi_version": "0.52.0",
+    "map_match_method": "TemplateMatch",
     "tags": [],
     "last_modified_time": 1753792140100,
     "enable_monster_loot_split": false

--- a/repo/js/批量讨伐角色养成材料BOSS/manifest.json
+++ b/repo/js/批量讨伐角色养成材料BOSS/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "批量讨伐角色养成材料BOSS",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "bgi_version": "0.60.2",
   "description": "一次性配置多个角色材料的boss，体力不足时保存进度，每次运行时断点续打",
   "authors": [


### PR DESCRIPTION
同步[批量讨伐角色养成材料BOSS](https://github.com/1004452714/AutoBoss/commits/main/)仓库的更新

  上次同步以来的变更：
  - 6da8284 Bump version to 0.7.1
- 6c1303a fix: 给可能途径分层地图的路径追踪文件更新bgi版本和地图匹配方式
