### PR TITLE
战斗策略：万能策略增加对杜林+克洛琳德+奈芙尔（改）的支持

### DIFF
--- a/repo/combat/万能战斗策略（萌新推荐）.txt
+++ b/repo/combat/万能战斗策略（萌新推荐）.txt
@@ -1,6 +1,6 @@
 // 作者：火山
 // 描述：（锄地+副本）请务必打开本文档仔细阅读说明设置！！！【此版本增加Check、ready两种新战斗策略语法的应用，实现自主动精准控制战斗结束检查时间点，有bug或者异常卡顿请及时向管理反馈】（内含少部分满命、进阶操作，默认已注释不开启。本策略作为示范教学，希望大家学习理解bgi战斗逻辑，如有更好的策略，欢迎提交）
-// 版本：v3.2
+// 版本：v3.3
 
 // 战斗配置设置流程
 // 该设置从调度器入口开始，按以下层级路径操作，核心为开启相关功能并配置关键参数。
@@ -117,7 +117,9 @@
 欧洛伦 e, attack(0.3), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), keypress(q), wait(0.1), check, wait(0.3)
 雷电将军 e, attack(0.22), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), keypress(q), wait(0.1), ready, check
 久岐忍 e, wait(0.3), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), e, check
-瓦雷莎 e, attack(1.25), wait(0.45), check, s(0.4), click(middle), e, attack(1.25), wait(0.3), keypress(q), wait(0.45), check
+瓦雷莎 e, attack(1.25), wait(0.45), check, s(0.4), click(middle), e, attack(1.25), wait(0.3), keypress(q), wait(0.45), check, wait(0.3)
+杜林 attack(0.08), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), ready, e, attack(0.2), wait(0.3), check, wait(0.3),keypress(q), wait(0.1), ready, check, wait(0.3)
+// （白龙）杜林 attack(0.05), wait(0.1), keypress(e), wait(0.3), keypress(e), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), keypress(q), wait(0.1), ready, check, wait(0.3)
 
 
 // 中置位
@@ -130,7 +132,7 @@
 
 // 减抗
 希诺宁 s(0.2), e, w(0.18), attack(0.7), keypress(x), wait(0.2), check, keypress(q), wait(0.1), keypress(q), wait(0.1), ready, attack, e, wait(0.3), check, wait(0.3)
-布伦妮 e, wait(0.3),check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.3)
+布伦妮 e, wait(0.3), check, wait(0.3), keypress(q), wait(0.1), keypress(q), check, wait(0.3)
 枫原万叶 attack(0.08), keypress(q), wait(0.1), keypress(q), wait(0.1), ready, keydown(E), wait(0.48), keyup(E), attack(0.3), wait(0.5), attack
 砂糖 e, attack(0.3), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), check, wait(0.3), e, attack(0.2)
 琴 attack(0.21), check, wait(0.3), keydown(e), wait(0.14), moveby(0, 1300), wait(0.75), keyup(e), attack(0.12), check, wait(0.3), keypress(q), wait(0.1), keypress(q), wait(0.1), ready, check, wait(0.3)
@@ -178,3 +180,7 @@
 // （6命单喷4s） 那维莱特 attack(0.05),click(middle), check, wait(0.3), e, wait(0.15), keydown(VK_LBUTTON), wait(0.27),keyup(VK_LBUTTON),wait(0.15),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),keydown(VK_LBUTTON),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-1100),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1200),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1300),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-1100),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1200),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1300),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-1100),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1200),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1300),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-2100),wait(0.05),moveby(1800,-1100),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1200),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,0),wait(0.05),moveby(1800,1300),wait(0.05),j,click(middle),click(middle),wait(0.05),keyup(VK_LBUTTON), check, wait(0.3)
 
 // （大团长满命策略） 法尔伽 attack(0.05), check, wait(0.3), e,attack(0.2),e,attack(0.1),e,attack(0.05),e,keydown(s),attack(1),keyup(s),attack(2.1),keydown(w),e,attack(0.05),e,attack(0.05),e,attack(0.2),e,keyup(w),keydown(s),attack(0.5),e,attack(0.5),e,keyup(s),attack(0.05),e,attack(0.05),e,attack(0.1),e,attack(0.1),e,attack(0.35),keypress(q),wait(0.1),keypress(q), wait(0.1), ready, check, wait(0.3)
+
+克洛琳德 attack(0.05), click(middle),keypress(E), wait(0.05), keydown(VK_LBUTTON), wait(0.58),keydown(s),wait(0.55),keyup(s), keypress(E),keyup(VK_LBUTTON),wait(0.01), keydown(VK_LBUTTON), wait(0.6),keydown(s),wait(0.54),keyup(s), keypress(E),keyup(VK_LBUTTON),wait(0.01), keydown(VK_LBUTTON), wait(0.6),keydown(s),wait(0.55),keyup(s),keypress(E),keyup(VK_LBUTTON),wait(0.01), keydown(VK_LBUTTON), wait(0.6),keydown(s),wait(0.54),keyup(s), keypress(E),keyup(VK_LBUTTON),wait(0.01), keydown(VK_LBUTTON), wait(0.6),keydown(s),wait(0.55),keyup(s),keypress(E),keyup(VK_LBUTTON),wait(0.01), keydown(VK_LBUTTON), wait(0.6),keydown(s),wait(0.54),keyup(s), keypress(E), keyup(VK_LBUTTON),attack(0.4),wait(0.15),keydown(q), wait(0.05),click(middle),keyup(q),check, wait(0.3)
+
+奈芙尔 attack(0.05),keydown(E),click(middle), keydown(S), keydown(VK_LBUTTON), wait(0.015), keyup(E), wait(0.7),attack(0.3), wait(0.015),keydown(VK_LBUTTON),keypress(VK_RBUTTON),keyup(S), wait(0.01), keydown(W), wait(0.7),attack(0.3),  wait(0.015),keydown(VK_LBUTTON),keypress(VK_RBUTTON),keyup(w),wait(0.01),keydown(S), wait(0.7),attack(0.3), keyup(S), wait(0.015),keyup(VK_LBUTTON),attack(0.05), check, wait(0.3),attack(0.05),keydown(E),click(middle), keydown(S), keydown(VK_LBUTTON), wait(0.015), keyup(E), wait(0.7),attack(0.3), wait(0.015),keydown(VK_LBUTTON),keypress(VK_RBUTTON),keyup(S), wait(0.01), keydown(W), wait(0.7),attack(0.3),  wait(0.015),keydown(VK_LBUTTON),keypress(VK_RBUTTON),keyup(w),wait(0.01),keydown(S), wait(0.7),attack(0.3), keyup(S), wait(0.015),keyup(VK_LBUTTON),attack(0.05), check, wait(0.3)


### PR DESCRIPTION
1. 奈芙尔策略为基础 E+3ZS 两套
2. 杜林默认为黑龙，白龙注释
3. 克洛琳德仅在6命账号测试过，低命未知

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 新增杜林、克洛琳德和奈芙尔三位角色的完整战斗操作策略

* **改进**
  * 优化调整了瓦雷莎、布伦妮和法尔加等既有角色的战斗指令链路
  * 扩充完善了大团长满命策略的操作序列
  * 策略版本更新至 v3.3，为萌新玩家提供更全面的战斗指导

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/babalae/bettergi-scripts-list/pull/3257?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->