### PR TITLE
fix(AutoPlan): 修复bug

### DIFF
--- a/repo/js/AutoPlan/README.md
+++ b/repo/js/AutoPlan/README.md
@@ -314,25 +314,24 @@
 | 0.0.6 | oiJbmjU2R0NniiwiZxh |           0.0.6+           |
 | 0.0.7 | oiJbmjU2R0NniiwiZxh |           0.0.6+           |
 | 0.0.8 | yHlw8FHjTJAPEtpp9O+ |           0.1.3+           |
+| 0.0.9 | yHlw8FHjTJAPEtpp9O+ |           0.1.3+           |
 
 ## 版本历史（简要）
 
 ---
+### 0.0.9 2026.06.12
+- 修复bug
 ### 0.0.8 2026.05.29
-
 - 新增执行记录功能(支持多次执行计划时单个配置只执行一次)
 - ![record](md/record.jpg)
 ### 0.0.7 2026.05.27
-
 - 重构配置模块：使用新的 UID 获取方法 `genshin.uid()` 替代 OCR 识别
 - 移除对 `ocrUid`、`getDayOfWeek`、`parseInteger`、`pullJsonConfig` 和 `findStygianOnslaught` 的导入
 - 添加对 `toMainUi` 的导入，在初始化时调用确保回到主界面
 - 更新最低 BetterGI 版本要求从 0.58.0 到 0.61.0
 - 删除 utils/uid.js 文件中的 `ocrUid` 函数实现
 - 优化 UID 获取逻辑，提升稳定性和准确性
-
 ### 0.0.6 2026.04.23
-
  - 限制单例模式配置
 ### 0.0.5 2026.04.11
 - 调整幽境危战 查找结果判断条件，增加名称不存在的情况处理

--- a/repo/js/AutoPlan/manifest.json
+++ b/repo/js/AutoPlan/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "自动体力计划",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "",
   "settings_ui": "settings.json",
   "main": "main.js",

--- a/repo/js/AutoPlan/utils/tool.js
+++ b/repo/js/AutoPlan/utils/tool.js
@@ -97,7 +97,7 @@ export function getJsonPath(key) {
     return commonMap.get(key); // 通过commonMap的get方法获取指定键对应的值
 }
 
-class UI{
+export class UI{
     /**
      * 检查当前是否在主界面
      * @returns {boolean} 如果在主界面则返回true，否则返回false
@@ -220,7 +220,7 @@ export async function outDomainUI() {
     await sleep(ms);
     //点击确认按钮
     await findTextAndClick('地脉异常')
-    await sleep(ms);
+    await sleep(ms*2);
     while (!await UI.isInOutDomainUI()) {
         if (UI.isInMainUI()) {
             inMainUI = true
@@ -236,7 +236,7 @@ export async function outDomainUI() {
         }
         index += 1
     }
-    if ((!tryMax) && (!inMainUI) && await isInOutDomainUI()) {
+    if ((!tryMax) && (!inMainUI) && await UI.isInOutDomainUI()) {
         try {
             //点击确认按钮
             await findTextAndClick('确认', ocrRegion.x, ocrRegion.y, ocrRegion.w, ocrRegion.h)


### PR DESCRIPTION
- 将 manifest.json 中的版本号从 0.0.8 更新为 0.0.9
- 在 README.md 的版本表格中添加 0.0.9 版本记录
- 在版本历史中添加 0.0.9 版本的发布日期和变更说明
- 记录 0.0.9 版本为修复 bug 版本

refactor(AutoPlan): 导出UI类并更新方法调用

- 将UI类标记为export以支持模块化导入
- 更新isInOutDomainUI方法调用为UI.isInOutDomainUI()静态方法调用
- 保持原有的业务逻辑不变，仅调整代码组织结构