### PR TITLE
地图追踪：巡陆艇 路径卡死修复

### DIFF
--- a/repo/pathing/敌人与魔物/巡陆艇/05-巡陆艇-设计局右下-7个.json
+++ b/repo/pathing/敌人与魔物/巡陆艇/05-巡陆艇-设计局右下-7个.json
@@ -6,10 +6,10 @@
         "name": "Tool_tingsu"
       }
     ],
-    "bgi_version": "0.50.0",
+    "bgi_version": "0.52.0",
     "description": "",
     "enable_monster_loot_split": false,
-    "last_modified_time": 1759731442558,
+    "last_modified_time": 1781837718568,
     "map_match_method": "",
     "map_name": "Teyvat",
     "name": "05-巡陆艇-设计局右下-7个",
@@ -215,24 +215,6 @@
       "type": "path",
       "x": 9752.5566,
       "y": 3102.0737
-    },
-    {
-      "action": "fight",
-      "action_params": "",
-      "id": 23,
-      "move_mode": "walk",
-      "type": "path",
-      "x": 9750.6855,
-      "y": 3113.1714
-    },
-    {
-      "action": "fight",
-      "action_params": "",
-      "id": 24,
-      "move_mode": "walk",
-      "type": "path",
-      "x": 9739.1299,
-      "y": 3100.4834
     }
   ]
 }


### PR DESCRIPTION
05-巡陆艇-设计局右下-7个：删除结尾容易卡在电梯底部的路径