### PR TITLE
fix: 放宽部分场景OCR识别强度

### DIFF
--- a/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
@@ -127,7 +127,7 @@ const clickToPrepare = () => {
 };
 /** 房间：查找加入准备区提示 */
 const findPrepareMsg = () => {
-  return findTextWithinBounds("加入准备", 576, 432, 768, 216, { contains: true });
+  return findTextWithinBounds("准备", 576, 432, 768, 216, { contains: true });
 };
 /** 存档：查找奇域收藏 */
 const findBeyondFavoritesBtn = () => {

--- a/repo/js/MiliastraExperiencePlayback/libs/modules/stage.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/modules/stage.js
@@ -28,9 +28,8 @@ const playStage = async (playbacks) => {
       () => findStageEscBtn() !== void 0 || findBottomBtnText("返回大厅") !== void 0,
       async () => {
         /** 关卡房间，点击 “开始游戏” 按钮 */
-        findBottomBtnText("开始游戏")?.click();
         /** 「经典模式」关卡，点击 “开始挑战” 按钮 */
-        findBottomBtnText("开始挑战")?.click();
+        findBottomBtnText("开始", true)?.click();
         /** 判断是否已经加入准备区 */
         if (findPrepareMsg()) {
           log.info("加入准备区...");

--- a/repo/js/MiliastraExperiencePlayback/libs/workflows/daily.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/workflows/daily.js
@@ -75,6 +75,8 @@ const execDailyTask = async () => {
         if (isHostException(err)) throw err;
         /** 发生脚本流程异常，尝试退出关卡（如果在关卡中） */
         await exitStage();
+        /** 发生脚本流程异常，尝试返回主界面 */
+        await genshin.returnMainUi();
         log.error("脚本执行出错: {error}", getErrorMessage(err));
       }
       /** 一轮关卡执行结束，更新数据存储 */

--- a/repo/js/MiliastraExperiencePlayback/libs/workflows/weekly.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/workflows/weekly.js
@@ -73,6 +73,8 @@ const execWeeklyTask = async () => {
       if (isHostException(err)) throw err;
       /** 发生脚本流程异常，尝试退出关卡（如果在关卡中） */
       await exitStage();
+      /** 发生脚本流程异常，尝试返回主界面 */
+      await genshin.returnMainUi();
       log.error("脚本执行出错: {error}", getErrorMessage(err));
     }
   await genshin.returnMainUi();

--- a/repo/js/MiliastraExperiencePlayback/manifest.json
+++ b/repo/js/MiliastraExperiencePlayback/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "千星奇域·每周经验刷取(回放通关版)",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "bgi_version": "0.61.0",
   "description": "千星奇域·每周经验刷取(回放通关版)",
   "authors": [


### PR DESCRIPTION
改动：
 - 修复房间内判断开始挑战条件过于严格，概率出现[进入关卡超时](https://github.com/breadgrocery/miliastra-experience-playback/issues/10)退出房间。