### PR TITLE
新增战斗策略：公式化锄地

### DIFF
--- a/repo/combat/公式化锄地.json
+++ b/repo/combat/公式化锄地.json
@@ -1,0 +1,280 @@
+{
+  "info": {
+    "name": "公式化锄地",
+    "author": "mno",
+    "description": "配队公式：芙+盾位（茜/机/尼/莱）+其他（火/万/莉/爱/少）用于普通精英/小怪锄地。检测战斗结束参数保持默认。",
+    "config": {},
+    "preActions": []
+  },
+  "actions": [
+    {
+      "name": "检查战斗结束",
+      "character": "",
+      "action": "check",
+      "condition": {
+        "expression": "t>3 && since>1"
+      },
+      "ensureCast": false,
+      "index": 1
+    },
+    {
+      "name": "奶奶-开盾",
+      "character": "茜特菈莉",
+      "action": "attack,e",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": true,
+      "index": 10
+    },
+    {
+      "name": "伊涅芙-开盾",
+      "character": "伊涅芙",
+      "action": "e",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": true,
+      "index": 11
+    },
+    {
+      "name": "尼可-开盾",
+      "character": "尼可",
+      "action": "e",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": true,
+      "index": 12
+    },
+    {
+      "name": "莱依拉-开盾",
+      "character": "莱依拉",
+      "action": "e",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": true,
+      "index": 13
+    },
+    {
+      "name": "爱可菲-q",
+      "character": "爱可菲",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "(low-hp || since(30)<3) && q-ready"
+      },
+      "ensureCast": false,
+      "index": 20,
+      "morePriorities": []
+    },
+    {
+      "name": "芙芙-e",
+      "character": "芙宁娜",
+      "action": "e,wait(0.3)",
+      "condition": {
+        "expression": "since>28 && e-ready"
+      },
+      "ensureCast": false,
+      "index": 21,
+      "morePriorities": [
+        {
+          "expression": "since>20 && e-ready",
+          "priority": 30
+        }
+      ]
+    },
+    {
+      "name": "火神-e",
+      "character": "玛薇卡",
+      "action": "attack,e",
+      "condition": {
+        "expression": "e-ready && since>15"
+      },
+      "ensureCast": false,
+      "index": 22
+    },
+    {
+      "name": "莉奈娅-大锤",
+      "character": "莉奈娅",
+      "action": "keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08),keypress(e),wait(0.08)",
+      "condition": {
+        "expression": "e-ready && since>17"
+      },
+      "ensureCast": false,
+      "index": 23
+    },
+    {
+      "name": "爱可菲-e",
+      "character": "爱可菲",
+      "action": "e,wait(0.45)",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": false,
+      "index": 24
+    },
+    {
+      "name": "少女-e",
+      "character": "哥伦比娅",
+      "action": "e",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": false,
+      "index": 25
+    },
+    {
+      "name": "火神-q",
+      "character": "玛薇卡",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 26
+    },
+    {
+      "name": "草神-破水盾",
+      "character": "纳西妲",
+      "action": "e,attack(1.2),charge(0.7),j,attack(0.8)",
+      "condition": {
+        "expression": "e-ready"
+      },
+      "ensureCast": false,
+      "index": 28
+    },
+    {
+      "name": "草神-q",
+      "character": "纳西妲",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 29,
+      "morePriorities": [
+        {
+          "expression": "low-hp",
+          "priority": 0
+        }
+      ]
+    },
+    {
+      "name": "芙芙-q",
+      "character": "芙宁娜",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 30
+    },
+    {
+      "name": "万叶-中e",
+      "character": "枫原万叶",
+      "action": "attack,keydown(E),wait(0.48),keyup(E),attack(0.3),wait(0.2)",
+      "condition": {
+        "expression": "since>8 || since>since(32)"
+      },
+      "ensureCast": false,
+      "index": 31
+    },
+    {
+      "name": "万叶-q",
+      "character": "枫原万叶",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 32
+    },
+    {
+      "name": "莉奈娅-q",
+      "character": "莉奈娅",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 33,
+      "morePriorities": [
+        {
+          "expression": "low-hp&&q-ready",
+          "priority": 20
+        }
+      ]
+    },
+    {
+      "name": "少女-q",
+      "character": "哥伦比娅",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 34
+    },
+    {
+      "name": "伊涅芙-q",
+      "character": "伊涅芙",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 35
+    },
+    {
+      "name": "奶奶-q",
+      "character": "茜特菈莉",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 36
+    },
+    {
+      "name": "莱依拉-q",
+      "character": "莱依拉",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 37
+    },
+    {
+      "name": "尼可-q",
+      "character": "尼可",
+      "action": "q,wait(0.1),ready",
+      "condition": {
+        "expression": "q-ready"
+      },
+      "ensureCast": false,
+      "index": 38
+    },
+    {
+      "name": "少女普攻挂水",
+      "character": "哥伦比娅",
+      "action": "attack",
+      "condition": {
+        "expression": ""
+      },
+      "ensureCast": false,
+      "index": 998
+    },
+    {
+      "name": "等待",
+      "character": "",
+      "action": "wait(0.2)",
+      "condition": {
+        "expression": ""
+      },
+      "ensureCast": false,
+      "index": 999
+    }
+  ]
+}


### PR DESCRIPTION
相对泛用的基础款锄地战斗策略，供满足配队公式的队伍使用，逻辑基础，保证技能覆盖率优先，不执行额外容易导致位移的动作