### PR TITLE
js: CD-Aware-AutoGather: 扫描模式和首次运行脚本时的细节改进

### DIFF
--- a/repo/js/CD-Aware-AutoGather/README.md
+++ b/repo/js/CD-Aware-AutoGather/README.md
@@ -7,7 +7,7 @@
 - 可设置一个或多个不运行的时间段
 - 采集过程自动切换合适的队伍
 
-**若脚本有问题，可[点击此处进行反馈](https://github.com/babalae/bettergi-scripts-list/issues/new?template=bug_report.yml&script-name=CD-Aware-AutoGather:2.5.0&additional-info=保留此行以便通知作者:%20@Patrick-Ze%0A%0A---%0A)**
+**若脚本有问题，可[点击此处进行反馈](https://github.com/babalae/bettergi-scripts-list/issues/new?template=bug_report.yml&script-name=CD-Aware-AutoGather:2.6.0&additional-info=保留此行以便通知作者:%20@Patrick-Ze%0A%0A---%0A)**
 
 # 使用前准备
 
@@ -119,7 +119,7 @@
 
 如果你的目标比较简单，比如想把地方特产都设为168，矿物都设为100，那只要在调度器中重复添加本脚本，然后分别设置不同的数量目标即可。
 
-如果你有更细致的需要，请将该选项设置为`csv`，然后执行一次材料扫描模式。扫描完成后，在record下找到对应账号的子文件夹。打开这个子文件夹，会找到一个`采集目标.csv`的csv文件。
+如果你有更细致的需要，请将该选项设置为`csv`，然后打开record文件夹下对应账号的子文件夹，会找到一个名为`采集目标`的csv文件。
 
 你可以用Excel或者WPS等打开此csv文件，打开后就是一个表格（如果你了解csv文件格式，也可以用任意文本编辑器打开，不过不推荐）。表格内容示例如下：
 

--- a/repo/js/CD-Aware-AutoGather/main.js
+++ b/repo/js/CD-Aware-AutoGather/main.js
@@ -46,14 +46,26 @@ class UserCancelled extends Error {
         const defaultRunMode = "扫描文件夹更新可选材料列表";
         log.warn("运行模式 未选择或无效: {0}，默认为{1}", runMode, defaultRunMode);
         runMode = defaultRunMode;
-        await sleep(3000);
+        await sleep(1000);
     }
 
     log.info("当前运行模式:{0}", runMode);
     if (runMode === "扫描文件夹更新可选材料列表") {
-        await runScanMode();
-        settings.runMode = "采集选中的材料";
-        log.info("扫描完成，自动更新设置：下次脚本将以{0}模式运行", settings.runMode);
+        const configMap = await runScanMode();
+        // 总是生成csv文件，以便需要csv模式时不必再重复运行脚本
+        const account = await getAccount();
+        updateTargetCountOfTasks({}, configMap, account, "csv");
+        const newRunMode = "采集选中的材料";
+        // 由于 https://github.com/babalae/better-genshin-impact/pull/3215
+        if (typeof settings.runMode === "undefined") {
+            // 如果用户从未打开过脚本配置页面，那么传递的设置是undefined，并且这种情况下脚本修改的设置无法被持久化
+            log.info("扫描完成，请在脚本配置中修改运行模式为{0}", newRunMode);
+        } else {
+            // 只要用户打开过脚本配置界面，即使点开后什么都没做，传递过来的也将是选项的default值，此时脚本修改的设置可以被持久化
+            log.info("扫描完成，自动更新设置：下次脚本将以{0}模式运行", newRunMode);
+        }
+        settings.runMode = newRunMode;
+        await sleep(2000);
     } else if (runMode === "采集选中的材料") {
         let startTime = logFakeScriptStart();
         await runGatherMode();
@@ -213,12 +225,7 @@ async function runGatherMode() {
     }
     log.info("共选中{0}种材料: {1}", materialNames.length, materialNames.join(", "));
 
-    let account = settings.manualSetAccountName || "";
-    if (!account) {
-        worldInfo = await getCoOpModeAndHostUid();
-        // 使用掩码后的UID作为账户名，避免浮窗和日志等意外暴露用户UID
-        account = worldInfo.maskUid;
-    }
+    let account = await getAccount();
 
     const groupedTasks = groupTasksByMaterialsName(selectedMaterials, account);
     const refreshedMaterials = Object.entries(groupedTasks)
@@ -279,6 +286,16 @@ async function runGatherMode() {
             throw e;
         }
     }
+}
+
+async function getAccount() {
+    let account = settings.manualSetAccountName || "";
+    if (!account) {
+        worldInfo = await getCoOpModeAndHostUid();
+        // 使用掩码后的UID作为账户名，避免浮窗和日志等意外暴露用户UID
+        account = worldInfo.maskUid;
+    }
+    return account;
 }
 
 function scanAndFilterJsonFiles(folderPath) {

--- a/repo/js/CD-Aware-AutoGather/manifest.json
+++ b/repo/js/CD-Aware-AutoGather/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "name": "带CD管理和目标设定的自动采集",
   "_version_note": "更新版本号时请一并更新README的问题反馈链接中的版本号",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "bgi_version": "0.55.0",
   "description": "自动同步你通过BetterGI订阅的地图追踪任务，执行采集任务，并管理材料采集目标和刷新时间。\n支持联机模式采集和多账号记录。\n首次使用前请先简单阅读说明",
   "authors": [


### PR DESCRIPTION
- 扫描模式: 总是生成csv文件，以便需要csv模式时不必再重复运行脚本 (Fix #3409)
- 首次运行: 根据是否能自动更新配置，进行不同的提示

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 扫描材料文件夹后，将自动生成或同步 CSV 采集目标。
  * 优化账号识别与采集模式切换流程，提升自动采集体验。

* **文档**
  * 更新问题反馈模板中的版本号至 2.6.0。
  * 简化“采集目标”CSV 文件的查找说明。

* **版本更新**
  * 扩展版本升级至 2.6.0。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->