### PR TITLE
fix: 修复目标关卡恰好位于首页首位时搜索失败的问题

### DIFF
--- a/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
@@ -43,10 +43,6 @@ const findCloseDialog = () => {
 const clickToContinue = () => {
   click(960, 1070);
 };
-/** 查找UID文本 */
-const findUidText = () => {
-  return findTextWithinBounds("UID", 1580, 1050, 340, 30, { contains: true });
-};
 /** 查找派蒙图标（判断处于奇域大世界/大厅） */
 const findPaimon = () => {
   const iro = findImageWithinBounds("assets/UI_Icon_Paimon.png", 0, 0, 100, 100, {
@@ -80,7 +76,9 @@ const findAllWonderlandsBtn = () => {
 };
 /** 房间：查找奇域搜索输入框 */
 const findSearchWonderlandInput = () => {
-  return findTextWithinBounds("搜索", 0, 120, 1920, 60, { contains: true });
+  const txt = findTextWithinBounds("搜索", 0, 120, 1920, 60, { contains: true });
+  txt?.drawSelf("group_text");
+  return txt;
 };
 /** 房间：查找奇域搜索输入框清除按钮 */
 const findClearInputBtn = () => {
@@ -90,21 +88,27 @@ const findClearInputBtn = () => {
 const findSearchWonderlandBtn = () => {
   return findTextWithinBounds("搜索", 0, 120, 1920, 60, { contains: true });
 };
-/** 房间：查找第一个奇域搜索结果名称 */
-const findFirstSearchResultText = () => {
+/** 房间：查找首行前N个奇域搜索结果名称 */
+const findTopNSearchResultTexts = (n) => {
+  const boundsN = (n) => [240 + n * 360, 475, 300, 50];
   const ir = captureGameRegion();
-  const ro = RecognitionObject.ocr(240, 475, 300, 50);
-  return (() => {
-    const list = ir.findMulti(ro);
-    for (let i = 0; i < list.count; i++)
-      if (list[i] && list[i].isExist()) {
-        const text = list[i].text.trim();
-        if (text) {
-          list[i].drawSelf("group_text");
-          return text;
-        }
-      }
-  })();
+  return [...Array(n).keys()]
+    .reverse()
+    .map((i) => {
+      return (() => {
+        const ro = RecognitionObject.ocr(...boundsN(i));
+        const list = ir.findMulti(ro);
+        for (let i = 0; i < list.count; i++)
+          if (list[i] && list[i].isExist()) {
+            const text = list[i].text.trim();
+            if (text) {
+              list[i].drawSelf("group_text");
+              return text;
+            }
+          }
+      })();
+    })
+    .reverse();
 };
 /** 房间：点击选择第一个搜索结果位置 */
 const clickToChooseFirstSearchResult = () => {
@@ -112,7 +116,9 @@ const clickToChooseFirstSearchResult = () => {
 };
 /** 房间：查找进入房间快捷键按钮 */
 const findEnterRoomShortcut = () => {
-  return findTextWithinBounds("房间", 1580, 110, 320, 390, { contains: true });
+  const txt = findTextWithinBounds("房间", 1580, 110, 320, 390, { contains: true });
+  txt?.drawSelf("group_text");
+  return txt;
 };
 /** 房间：查找退出房间按钮 */
 const findLeaveRoomBtn = () => {
@@ -128,7 +134,9 @@ const findGoToLobbyBtn = () => {
 };
 /** 房间：查找创建房间按钮 */
 const findCreateRoomBtn = () => {
-  return findTextWithinBounds("房间", 960, 95, 960, 70, { contains: true });
+  const txt = findTextWithinBounds("房间", 960, 95, 960, 70, { contains: true });
+  txt?.drawSelf("group_text");
+  return txt;
 };
 /** 房间：点击加入准备区位置 */
 const clickToPrepare = () => {
@@ -174,7 +182,9 @@ const findSaveToDeletePos = (keyword) =>
   );
 /** 存档：查找局外存档列头 */
 const findExternalSaveColumnPos = () => {
-  return findTextWithinBounds("局外", 55, 190, 1810, 50, { contains: true });
+  const txt = findTextWithinBounds("局外", 55, 190, 1810, 50, { contains: true });
+  txt?.drawSelf("group_text");
+  return txt;
 };
 /** 存档：查找删除局外存档复选框已选中状态 */
 const findDeleteExternalSaveChecked = (colPos) => {
@@ -191,7 +201,9 @@ const findDeleteStageSaveBtn = () => {
 };
 /** 关卡：查找结算跳过按钮 */
 const findSkipBtn = () => {
-  return findTextWithinBounds("跳过", 1720, 0, 200, 100, { contains: true });
+  const txt = findTextWithinBounds("跳过", 1720, 0, 200, 100, { contains: true });
+  txt?.drawSelf("group_text");
+  return txt;
 };
 /** 关卡：查找关卡退出按钮 */
 const findStageEscBtn = () => {
@@ -208,7 +220,9 @@ const findExitStageBtn = () => {
 };
 /** 退出：查找返回提瓦特按钮 */
 const findGotTeyvatBtn = () => {
-  return findTextWithinBounds("返回", 1500, 0, 300, 95, { contains: true });
+  const txt = findTextWithinBounds("返回", 1500, 0, 300, 95, { contains: true });
+  txt?.drawSelf("group_text");
+  return txt;
 };
 /** 纪游：查找诸界纪游按钮 */
 const findBeyondBattlepassBtn = () => {
@@ -264,7 +278,6 @@ export {
   findExitStageBtn,
   findExternalSaveColumnPos,
   findFetchRewardBtn,
-  findFirstSearchResultText,
   findGoToLobbyBtn,
   findGotTeyvatBtn,
   findHeaderTitle,
@@ -279,5 +292,5 @@ export {
   findSetupFilterBtn,
   findSkipBtn,
   findStageEscBtn,
-  findUidText,
+  findTopNSearchResultTexts,
 };

--- a/repo/js/MiliastraExperiencePlayback/libs/constants/store.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/constants/store.js
@@ -1,24 +1,20 @@
-import { __name } from "../rolldown-runtime.js";
 import { getNextDay4AM, getNextMonday4AM, useStoreWithDefaults } from "../@bettergi+utils.js";
-import { findUidText } from "./regions.js";
 
 //#region src/constants/store.ts
+const uidNumber = await genshin.uid();
+if (!uidNumber) throw new Error("创建用户数据存储失败：无法识别UID");
 /** 脚本数据存储 */
-const store = (() => {
-  /** 识别UID */
-  const uid = findUidText()?.text.replace(/\D/g, "");
-  if (!uid) throw new Error("创建用户数据存储失败: 无法识别UID");
-  return useStoreWithDefaults(uid, {
-    uid,
-    weekly: {
-      expGained: 0,
-      attempts: 0,
-    },
-    daily: { attempts: 0 },
-    nextWeek: getNextMonday4AM().getTime(),
-    nextDay: getNextDay4AM().getTime(),
-  });
-})();
+const uid = String(uidNumber);
+const store = useStoreWithDefaults(uid, {
+  uid,
+  weekly: {
+    expGained: 0,
+    attempts: 0,
+  },
+  daily: { attempts: 0 },
+  nextWeek: getNextMonday4AM().getTime(),
+  nextDay: getNextDay4AM().getTime(),
+});
 
 //#endregion
 export { store };

--- a/repo/js/MiliastraExperiencePlayback/libs/modules/reawrd.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/modules/reawrd.js
@@ -18,8 +18,9 @@ import { isInLobby } from "./lobby.js";
 //#region src/modules/reawrd.ts
 /** 领取诸界纪游经验 */
 const fetchBattlepassExp = async () => {
+  log.info(`尝试领取诸界纪游经验...`);
   if (!userConfig.dailyRewards.includes("诸界纪游")) {
-    log.warn("跳过领取诸界纪游经验");
+    log.warn("未配置领取诸界纪游奖励，跳过领取诸界纪游经验");
     return;
   }
   /** 确保处于大厅内 */

--- a/repo/js/MiliastraExperiencePlayback/libs/modules/room.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/modules/room.js
@@ -7,12 +7,12 @@ import {
   findConfirmBtn,
   findCreateRoomBtn,
   findEnterRoomShortcut,
-  findFirstSearchResultText,
   findGoToLobbyBtn,
   findHeaderTitle,
   findLeaveRoomBtn,
   findSearchWonderlandBtn,
   findSearchWonderlandInput,
+  findTopNSearchResultTexts,
 } from "../constants/regions.js";
 import { isInLobby } from "./lobby.js";
 
@@ -40,17 +40,17 @@ const createRoom = async (room) => {
       findAllWonderlandsBtn()?.click();
     },
   );
-  /** 帮助函数：获取第一个奇域名称 */
-  const firstWonderlandName = async (maxAttempts = 5, retryInterval = 2e3) => {
+  /** 帮助函数：获取首行奇域名称 */
+  const findTopWonderlandNames = async (maxAttempts = 5, retryInterval = 2e3) => {
     for (let i = 0; i < maxAttempts; i++) {
       await sleep(retryInterval);
-      const text = findFirstSearchResultText();
-      if (text) return text;
+      const texts = findTopNSearchResultTexts(4);
+      if (texts.some((t) => t !== void 0)) return texts;
     }
   };
-  const iwnt = await firstWonderlandName();
-  if (iwnt === void 0) throw new Error("奇域列表加载超时");
-  log.info("搜索前的首个奇域关卡名称: {iwnt}", iwnt);
+  const iwnts = await findTopWonderlandNames();
+  if (iwnts === void 0) throw new Error("奇域列表加载超时");
+  log.info("搜索前的奇域关卡名称: {iwnt}", iwnts.join(", "));
   log.info("粘贴奇域关卡文本: {room}", room);
   await assertRegionAppearing(findClearInputBtn, "粘贴关卡文本超时", () => {
     const input = findSearchWonderlandInput();
@@ -60,20 +60,20 @@ const createRoom = async (room) => {
     }
   });
   /** 等待搜索结果变化 */
-  let lwnt;
+  let lwnts;
   log.info("搜索奇域关卡: {room}", room);
   await waitForAction(
     () => {
-      if (lwnt === void 0) return false;
-      const isChanged = lwnt.toLowerCase().trim() !== iwnt.toLowerCase().trim();
-      if (isChanged) log.info("首个奇域关卡名称已变化: {lwnt}，搜索完成", lwnt);
+      if (lwnts === void 0) return false;
+      const isChanged = lwnts.some((text, i) => text?.toLowerCase() !== iwnts[i]?.toLowerCase());
+      if (isChanged) log.info("奇域关卡名称已变化: {lwnt}，搜索完成", lwnts[0]);
       return isChanged;
     },
     async () => {
       const searchBtn = findSearchWonderlandBtn();
       if (searchBtn) {
         searchBtn.click();
-        lwnt = await firstWonderlandName();
+        lwnts = await findTopWonderlandNames();
       }
     },
     {

--- a/repo/js/MiliastraExperiencePlayback/manifest.json
+++ b/repo/js/MiliastraExperiencePlayback/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "千星奇域·经验刷取(回放通关版)",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "bgi_version": "0.61.0",
   "description": "千星奇域·经验刷取(回放通关版)",
   "authors": [


### PR DESCRIPTION
改动内容：
  - 修复目标关卡恰好位于首页首位时搜索失败的问题（极端情况）
  - 改用使用内置UID识别函数解决[UID不能稳定识别的问题](https://github.com/breadgrocery/miliastra-experience-playback/issues/12)
  - 新增部分日志打印和绘制调试框