### PR TITLE
js：采集cd管理3.0.2

### DIFF
--- a/repo/js/AAA-Artifacts-Bulk-Supply/main.js
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/main.js
@@ -1012,7 +1012,7 @@ async function runPaths(folderFilePath, PartyName, doStop, furinaRequirement = "
         }
         const pathInfo = await parsePathing(Path.fullPath);
         try {
-            log.info(`当前进度：${Path.fileName}为${folderFilePath}第${i + 1}/${Paths.length}个`);
+            log.info(`${Path.fileName}为${folderFilePath}第${i + 1}/${Paths.length}个`);
             await runPath(Path.fullPath, null);
             await sleep(1);
         } catch (error) {

--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -1949,7 +1949,7 @@ async function processPathingsByGroup(pathings, accountName) {
             const remaininghours = Math.floor(predictRemainingTime / 3600);
             const remainingminutes = Math.floor((predictRemainingTime % 3600) / 60);
             const remainingseconds = predictRemainingTime % 60;
-            log.info(`当前进度：第 ${targetGroup} 组第 ${groupPathCount}/${totalPathsInGroup} 个  ${pathing.fileName}已完成，该组预计剩余: ${remaininghours} 时 ${remainingminutes} 分 ${remainingseconds.toFixed(0)} 秒`);
+            log.info(`第 ${targetGroup} 组第 ${groupPathCount}/${totalPathsInGroup} 个  ${pathing.fileName}已完成，该组预计剩余: ${remaininghours} 时 ${remainingminutes} 分 ${remainingseconds.toFixed(0)} 秒`);
 
             let fileEndX = 0, fileEndY = 0;
             try {

--- a/repo/js/采集cd管理/README.md
+++ b/repo/js/采集cd管理/README.md
@@ -96,13 +96,108 @@
 ---
 
 ### 五、**📞 联系方式**
-- **QQ群**：1057307824
+- **QQ群**：1057307824（备用1071793282）
   - 测测莫酱（有其他问题也行）
-  - 茶包版bgi具有许多公版bgi没有的功能，想要测测茶包也可以加群
+- 不接受github渠道的问题反馈，只接受加群处理
 
 ---
 
-### 六、**📦 莫酱全家桶（部分）**
+### 六、**📋 Schedule 执行**
+<details>
+<summary>点击查看详情</summary>
+
+#### 功能说明
+
+采集cd管理支持执行 schedule 文件，可以将多个地图追踪或js脚本按顺序执行。
+
+#### 文件格式
+
+```json
+{
+  "schedule": [
+    { "action": "start", "task": "任务名", "count": 1 },
+    { "action": "wait", "task": "任务名" }
+  ],
+  "tasks": [
+    {
+      "name": "任务名",
+      "type": "autopathing",
+      "filePath": "路径/地图追踪.json"
+    }
+  ]
+}
+```
+
+#### schedule 数组
+
+定义任务执行顺序：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `action` | string | 是 | 动作类型：`start` 或 `wait` |
+| `task` | string | 是 | 任务名称，对应 tasks 中的 name |
+| `count` | number | 否 | 执行次数，仅 start 有效，默认 1 |
+
+**action 类型：**
+- `start`: 启动任务，任务是否异步等待由 tasks 中 `async` 字段控制（默认 false，同步等待完成）
+- `wait`: 等待异步任务完成
+
+#### tasks 数组
+
+定义所有可用的任务：
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `name` | string | 是 | 任务名称，唯一标识 |
+| `type` | string | 是 | 任务类型 |
+| `filePath` | string | 是 | 文件路径，相对于采集cd管理目录 |
+| `settings` | object | 否 | 传递给任务的配置参数（仅 js 类型有效，传入脚本入口函数） |
+| `async` | boolean | 否 | 是否异步执行，默认 false。设为 true 后 start 不等待完成，需搭配 schedule 中的 `wait` action |
+
+**type 类型（大小写不敏感）：**
+
+| 值 | 说明 | filePath 示例 |
+|------|------|------|
+| `autopathing` | 地图追踪 | `pathing/挖矿/水晶矿.json` |
+| `js` | 子脚本 | `subJs/脚本文件夹/` |
+| `keymousescript` | 键鼠脚本 | `assets/滚轮下翻.json` |
+
+#### 示例
+
+```json
+{
+  "schedule": [
+    { "action": "start", "task": "采集任务" },
+    { "action": "start", "task": "锄地任务" }
+  ],
+  "tasks": [
+    {
+      "name": "采集任务",
+      "type": "autopathing",
+      "filePath": "pathing/水晶矿.json"
+    },
+    {
+      "name": "锄地任务",
+      "type": "js",
+      "filePath": "subJs/AutoHoeingOneDragon/",
+      "settings": {}
+    }
+  ]
+}
+```
+
+#### 注意事项
+
+1. **路径格式**：`filePath` 路径使用正斜杠 `/`
+2. **识别逻辑**：读取 JSON 文件后，如果包含 `schedule` 和 `tasks` 字段，则视为 schedule 文件执行
+3. **拾取支持**：执行 schedule 期间会全程执行模板匹配交互和拾取
+4. **settings 格式**：`settings` 对象格式与配置组文件中相同，建议在配置组中配好子 js 的自定义配置后，复制配置组中的部分
+
+</details>
+
+---
+
+### 七、**📦 莫酱全家桶（部分）**
 - 日常使用
   - 锄地一条龙：一站式解决自动化锄地，支持只拾取狗粮
   - AAA狗粮批发：自动卡时间拿狗粮，收益最大化
@@ -117,7 +212,7 @@
 
 ---
 
-### 七、**📋 更新日志**
+### 八、**📋 更新日志**
 
 <details>
 <summary>点击查看历史更新</summary>

--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -1208,6 +1208,17 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
 
     const raw = file.readTextSync(filePath);
     const json = JSON.parse(raw);
+
+    // 检测是否为 schedule 文件（包含 schedule 和 tasks 字段）
+    if (json.schedule && json.tasks) {
+        log.info(`检测到 schedule 文件: ${fileName}，使用 schedule 模式执行`);
+        const pickupTask = recognizeAndInteract();
+        await executeSchedule(filePath);
+        state.running = false;
+        await pickupTask;
+        return { success: true, lastMapName: "", runPickupLog: [], isSchedule: true };
+    }
+
     const mapName = (json.info?.map_name && json.info.map_name.trim()) ? json.info.map_name : 'Teyvat';
     await handleUnderwaterRoute(mapName, filePath, lastMapName);
     lastMapName = mapName;
@@ -1457,16 +1468,28 @@ function calculateRouteEfficiency(files, cdMap, options = {}) {
                 continue;
             }
 
+            // 解析路线声明（【】格式）
+            const dec = parseDeclaration(file.description);
+
             // 计算仅看优先材料的分均效率
             let eff = -2; // 未知标记
             if (rec?.history && rec.history.length >= 3) {
                 const effList = rec.history.map(log => {
-                    const total = Object.entries(log.items)
+                    const mergedItems = { ...log.items, ...(dec.declaredMaterials || {}) };
+                    const total = Object.entries(mergedItems)
                         .filter(([name]) => priorityItemSet.has(name))
                         .reduce((sum, [, cnt]) => sum + cnt, 0);
                     return (total / log.durationSec) * 60;
                 });
                 eff = effList.reduce((a, b) => a + b, 0) / effList.length;
+            } else if (dec.declaredDuration || dec.declaredMaterials) {
+                // 历史不足 3 条，但有声明：用声明时间 + 声明数量覆盖历史
+                const duration = dec.declaredDuration || rec?.history?.[0]?.durationSec || 60;
+                const mergedItems = { ...(rec?.history?.[0]?.items || {}), ...(dec.declaredMaterials || {}) };
+                const total = Object.entries(mergedItems)
+                    .filter(([name]) => priorityItemSet.has(name))
+                    .reduce((sum, [, cnt]) => sum + cnt, 0);
+                eff = (total / duration) * 60;
             }
             file._priorityEff = eff;
         }
@@ -1497,16 +1520,28 @@ function calculateRouteEfficiency(files, cdMap, options = {}) {
             const fullName = basename(p.fullPath);
             const obj = cdMap.get(fullName);
             let avgEff = -1; // 先标记为"未知"
+            const dec = parseDeclaration(p.description);
 
             if (obj && obj.history && obj.history.length >= 3) {
+                // 历史 ≥3 条：用历史时间，但声明中的材料数量覆盖历史
                 const effList = obj.history.map(log => {
-                    const total = Object.entries(log.items).reduce((sum, [name, cnt]) => {
+                    const mergedItems = { ...log.items, ...(dec.declaredMaterials || {}) };
+                    const total = Object.entries(mergedItems).reduce((sum, [name, cnt]) => {
                         const w = blacklistSet.has(name) ? 0 : (weightMap.get(name) ?? 1);
                         return sum + cnt * w;
                     }, 0);
                     return (total / log.durationSec) * 60;
                 });
                 avgEff = effList.reduce((a, b) => a + b, 0) / effList.length;
+            } else if (dec.declaredDuration || dec.declaredMaterials) {
+                // 历史不足 3 条，但有声明：用声明时间 + 声明数量覆盖历史
+                const duration = dec.declaredDuration || obj?.history?.[0]?.durationSec || 60;
+                const mergedItems = { ...(obj?.history?.[0]?.items || {}), ...(dec.declaredMaterials || {}) };
+                const total = Object.entries(mergedItems).reduce((sum, [name, cnt]) => {
+                    const w = blacklistSet.has(name) ? 0 : (weightMap.get(name) ?? 1);
+                    return sum + cnt * w;
+                }, 0);
+                avgEff = (total / duration) * 60;
             }
             p._efficiency = avgEff; // 已知路线存真实效率，未知路线存 -1
         });
@@ -2452,13 +2487,22 @@ async function processPriorityItems() {
             /* ---------- 智能选队：按路线所在文件夹反查路径组 ---------- */
             await selectPartyByRoutePath(bestRoute.fullPath, "优先采集阶段");
 
-            log.info(`当前进度：执行路线 ${fileName}，剩余优先材料：${remaining}`);
+            log.info(`执行路线 ${fileName}，剩余优先材料：${remaining}`);
 
             let timeNow = new Date();
             await handleIngredientProcessing(timeNow);
 
             await handleTimeAdjustment(timeNow);
             await fakeLog(fileName, false, true, 0);
+
+            // 优先采集模式不支持 schedule 任务，静默跳过
+            try {
+                const routeJson = JSON.parse(file.readTextSync(filePath));
+                if (routeJson.schedule && routeJson.tasks) {
+                    continue;
+                }
+            } catch (e) { /* ignore */ }
+
             routeRunCount[fullName] = (routeRunCount[fullName] || 0) + 1;
 
             /* ========== 历史拾取物前置排序 ========== */
@@ -2471,7 +2515,10 @@ async function processPriorityItems() {
                 continue;
             }
             lastMapName = routeResult.lastMapName;
-            routeResult.runPickupLog.forEach(name => {
+            /* ===== 用声明材料数量修正拾取日志 ===== */
+            const correctedLog = correctPickupLogByDeclaration(routeResult.runPickupLog, bestRoute.fullPath);
+            /* ===================================== */
+            correctedLog.forEach(name => {
                 /* 就地展开：别名→本名数组，再把所有相关名称都计数 */
                 const realNames = alias2Names.get(name) || [name]; // 可能是多个本名
                 for (const rn of realNames) {
@@ -2509,8 +2556,8 @@ async function processPriorityItems() {
 
             /* ================================================ */
 
-            /* ---------- 3. 统一写文件 & 清空日志 ---------- */
-            await saveRecordAndClearLog(cdMap, recordFilePath, routeResult.runPickupLog);
+            /* ---------- 3. 统一写文件 & 清空日志（用声明修正后的日志） ---------- */
+            await saveRecordAndClearLog(cdMap, recordFilePath, correctedLog);
             if (priorityList.length <= 0) {
                 log.info('每日优先材料已达标，退出优先采集阶段');
                 notification.send('每日优先材料已达标，退出优先采集阶段');
@@ -2654,7 +2701,7 @@ async function processPathGroups() {
                         targetItems = prioritizeHistoricalItems(targetItems, cdMap, fullName);
                         /* ======================================= */
 
-                        log.info(`当前进度：执行路线 ${fileName}，路径组${i} ${folder} 第 ${groupFiles.indexOf(filePath) + 1}/${groupFiles.length} 个`);
+                        log.info(`执行路线 ${fileName}，路径组${i} ${folder} 第 ${groupFiles.indexOf(filePath) + 1}/${groupFiles.length} 个`);
                         log.info(`当前路线分均效率为 ${(filePath._efficiency ?? 0).toFixed(2)}`);
 
                         state.runPickupLog = [];          // 新路线开始前清空
@@ -2673,15 +2720,24 @@ async function processPathGroups() {
                         const timeDiff = endTime.getTime() - startTime.getTime();
                         if (timeDiff > 10000) {
                             /* ---------- 2. 仅当 pathRes === true 才计算并更新 CD ---------- */
-                            let pathRes = isArrivedAtEndPoint(filePath.fullPath);
-                            if (pathRes) {
-                                const newTimestamp = calculateRouteCD(currentCdType, startTime);
+                            if (routeResult.isSchedule) {
+                                // Schedule 任务使用路径组配置的 CD 类型，未配置时默认"1次0点刷新"
+                                const cdType = currentCdType || "1次0点刷新";
+                                const newTimestamp = calculateRouteCD(cdType, startTime);
                                 targetObj.cdTime = newTimestamp.toISOString();
-                                log.info(`本任务cd信息已更新，下一次可用时间为 ${newTimestamp.toLocaleString()}`);
+                                log.info(`schedule任务CD信息已更新，下一次可用时间为 ${newTimestamp.toLocaleString()}`);
+                            } else {
+                                let pathRes = isArrivedAtEndPoint(filePath.fullPath);
+                                if (pathRes) {
+                                    const newTimestamp = calculateRouteCD(currentCdType, startTime);
+                                    targetObj.cdTime = newTimestamp.toISOString();
+                                    log.info(`本任务cd信息已更新，下一次可用时间为 ${newTimestamp.toLocaleString()}`);
+                                }
                             }
 
-                            /* ---------- 3. 统一写文件 & 清空日志 ---------- */
-                            await saveRecordAndClearLog(cdMap, recordFilePath, routeResult.runPickupLog);
+                            /* ---------- 3. 用声明材料数量修正拾取日志后统一写文件 ---------- */
+                            const correctedLog = correctPickupLogByDeclaration(routeResult.runPickupLog, filePath.fullPath);
+                            await saveRecordAndClearLog(cdMap, recordFilePath, correctedLog);
                             routeRunCount[fullName] = (routeRunCount[fullName] || 0) + 1;
 
                             if (settings.loopCollect) {
@@ -2699,5 +2755,504 @@ async function processPathGroups() {
             i++;
         }
         await sleep(1000);
+    }
+}
+
+/**
+ * 加载并处理子JS脚本，返回处理后的代码（不执行）
+ * @param {string} jsFilePath - 子脚本所在文件夹路径
+ * @returns {Object} { code: 处理后的代码字符串, basePath: 标准化后的基础路径, scriptName: 脚本名称 }
+ */
+function loadSubJS(jsFilePath) {
+    // ========== 1. 基础配置 ==========
+    const normalizedBasePath = jsFilePath
+        .replace(/[\\/]+/g, '/')
+        .replace(/\/+$/, '') + '/';
+    
+    try {
+        // ========== 1.1 读取 manifest.json ==========
+        const manifestPath = `${normalizedBasePath}manifest.json`;
+        const manifestContent = file.readTextSync(manifestPath);
+        const manifest = JSON.parse(manifestContent);
+        
+        // 获取入口文件名
+        const mainFileName = manifest.main || 'main.js';
+        const filePath = `${normalizedBasePath}${mainFileName}`;
+
+        // ========== 2. 读取子JS ==========
+        let rawCode = file.readTextSync(filePath);
+
+        // ========== 3. 替换API名称 ==========
+        const apiReplaceMap = {
+            'file.ReadPathSync': '_file_ReadPathSync',
+            'file.readTextSync': '_file_readTextSync',
+            'file.readText': '_file_readText',
+            'file.ReadImageMatSync': '_file_ReadImageMatSync',
+            'file.writeTextSync': '_file_writeTextSync',
+            'file.writeText': '_file_writeText',
+            'file.WriteImageSync': '_file_WriteImageSync',
+            'file.IsFolder': '_file_IsFolder',
+            'pathingScript.runFile': '_pathingScript_runFile',
+            'keyMouseScript.runFile': '_keyMouseScript_runFile'
+        };
+        Object.keys(apiReplaceMap).sort((a, b) => b.length - a.length).forEach(originalApi => {
+            const customApi = apiReplaceMap[originalApi];
+            // 构建大小写不敏感的正则表达式
+            // 将每个字符转换为可选大小写的形式，例如 "file" 变为 "[fF][iI][lL][eE]"
+            const caseInsensitiveApi = originalApi.split('').map(char => {
+                if (char.match(/[a-zA-Z]/)) {
+                    return `[${char.toLowerCase()}${char.toUpperCase()}]`;
+                }
+                return char === '.' ? '\\.' : char;
+            }).join('');
+            const regex = new RegExp(`\\b(${caseInsensitiveApi})\\b`, 'g');
+            rawCode = rawCode.replace(regex, customApi);
+        });
+
+        // ========== 4. 处理脚本执行模式 ==========
+        // 将子脚本中的唯一外层 async IIFE 改为命名函数，并在最后 await 它
+        const trimmedCode = rawCode.trim();
+        const asyncIifeCount = (trimmedCode.match(/\(async function\s*\(/g) || []).length;
+        
+        if (asyncIifeCount === 1) {
+            // 找到唯一的 async IIFE
+            const asyncIifeStart = trimmedCode.indexOf('(async function');
+            
+            // 找到这个 IIFE 的结束位置（需要匹配括号）
+            let braceCount = 0;
+            let foundFirstBrace = false;
+            let iifeEnd = -1;
+            for (let i = asyncIifeStart; i < trimmedCode.length; i++) {
+                if (trimmedCode[i] === '{') {
+                    braceCount++;
+                    foundFirstBrace = true;
+                } else if (trimmedCode[i] === '}') {
+                    braceCount--;
+                }
+                // 当找到配对的 } 后，再往后找 })();
+                if (foundFirstBrace && braceCount === 0) {
+                    const nextChars = trimmedCode.substring(i, i + 5);
+                    if (nextChars === '})();') {
+                        iifeEnd = i + 5;
+                        break;
+                    }
+                }
+            }
+            
+            if (asyncIifeStart >= 0 && iifeEnd > asyncIifeStart) {
+                const beforeIife = trimmedCode.substring(0, asyncIifeStart).trim();
+                const iifeCode = trimmedCode.substring(asyncIifeStart, iifeEnd);
+                const firstBrace = iifeCode.indexOf('{');
+                const lastBrace = iifeCode.lastIndexOf('}');
+                const iifeBody = iifeCode.substring(firstBrace + 1, lastBrace).trim();
+                const afterIife = trimmedCode.substring(iifeEnd).trim();
+                
+                rawCode = `return (async function() {\n${beforeIife}\n${afterIife}\nasync function __subJsMain__() {\n${iifeBody}\n}\nawait __subJsMain__();\n})();`;
+            } else {
+                rawCode = `return (async function() {\n${rawCode}\n})();`;
+            }
+        } else {
+            // 没有或有多个 async IIFE，直接包裹整个脚本
+            rawCode = `return (async function() {\n${rawCode}\n})();`;
+        }
+
+        // ========== 5. 构建自定义API代码 ==========
+        const customApiLines = [
+            '"use strict";',
+            `const basePath = ${JSON.stringify(normalizedBasePath)};`,
+            '',
+            'function _joinPath(pathArg) {',
+            '    if (typeof pathArg !== "string") return pathArg;',
+            '    // 确保不会重复添加 basePath（大小写不敏感）',
+            '    if (pathArg.toLowerCase().startsWith(basePath.toLowerCase())) return pathArg;',
+            '    // 确保路径格式正确',
+            '    const joined = basePath + pathArg.replace(/^[\\/]?/, "");',
+            '    return joined.replace(/[\\/]+/g, "/");',
+            '}',
+            '',
+            'function _file_ReadPathSync(...args) {',
+            '    try {',
+            '        // 对输入路径参数添加 basePath 前缀',
+            '        const processedArgs = args.map(arg => _joinPath(arg));',
+            '        const results = file.ReadPathSync(...processedArgs);',
+            '        const newResults = [];',
+            '        if (results) {',
+            '            for (const res of results) {',
+            '                // 按正反斜杠划分路径，去空，去除base的部分，再重新构建',
+            '                const pathParts = res.split(/[\\\\/]/).filter(part => part !== "");',
+            '                const baseParts = basePath.split(/[\\\\/]/).filter(part => part !== "");',
+            '                let processedParts = [];',
+            '                let inBasePath = true;',
+            '                ',
+            '                for (const part of pathParts) {',
+            '                    if (inBasePath && baseParts.length > 0) {',
+            '                        if (part.toLowerCase() === baseParts[0].toLowerCase()) {',
+            '                            baseParts.shift();',
+            '                        } else {',
+            '                            inBasePath = false;',
+            '                            processedParts.push(part);',
+            '                        }',
+            '                    } else {',
+            '                        processedParts.push(part);',
+            '                    }',
+            '                }',
+            '                ',
+            '                const processedRes = processedParts.join("\\\\");',
+            '                newResults.push(processedRes);',
+            '            }',
+            '        }',
+            '        return newResults;',
+            '    } catch (e) {',
+            '        log.error(`_file_ReadPathSync 执行失败：${e.message}`);',
+            '        return [];',
+            '    }',
+            '}',
+            '',
+            'async function _file_readText(...args) { return await file.readText(...args.map(arg => _joinPath(arg))); }',
+            'function _file_readTextSync(...args) { return file.readTextSync(...args.map(arg => _joinPath(arg))); }',
+            'function _file_WriteImageSync(...args) { return file.WriteImageSync(...args.map(arg => _joinPath(arg))); }',
+            'function _file_IsFolder(...args) { return file.IsFolder(...args.map(arg => _joinPath(arg))); }',
+            'function _pathingScript_runFile(...args) { return pathingScript.runFile(...args.map(arg => _joinPath(arg))); }',
+            'function _keyMouseScript_runFile(...args) { return keyMouseScript.runFile(...args.map(arg => _joinPath(arg))); }',
+            '',
+            'function _file_ReadImageMatSync(...args) {',
+            '    try {',
+            '        const processedArgs = args.map(arg => {',
+            '            const j = _joinPath(arg);',
+            '            return typeof j === "string" && !j.match(/\.(png|jpg|jpeg|bmp)$/i) ? j + ".png" : j;',
+            '        });',
+            '        const result = file.ReadImageMatSync(...processedArgs);',
+            '        return result;',
+            '    } catch (e) {',
+            '        log.error(`_file_ReadImageMatSync 执行失败：${e.message}`);',
+            '        throw e;',
+            '    }',
+            '}',
+            '',
+            'function _file_writeText(filePath, content, append) { file.writeText(_joinPath(filePath), content, append); return true; }',
+            'function _file_writeTextSync(filePath, content, append = false) { file.writeTextSync(_joinPath(filePath), content, append); return true; }',
+            ''
+        ];
+
+        // ========== 6. 组合代码 ==========
+        let fullCode = [...customApiLines, ...rawCode.split('\n')].join('\n');
+
+        // ========== 7. 返回处理后的代码、路径信息和原始路径 ==========
+        return {
+            code: fullCode,
+            basePath: normalizedBasePath,
+            jsFilePath: jsFilePath
+        };
+
+    } catch (e) {
+        log.error(`loadSubJS执行失败：${e.message}\n错误堆栈：${e.stack}`);
+        throw e;
+    }
+}
+
+/**
+ * 在正确上下文中执行处理后的子脚本代码
+ * 使用 new Function 创建独立作用域，避免全局变量污染
+ * @param {Object} subJS - loadSubJS 返回的对象 { code, basePath, jsFilePath }
+ * @param {Object} settings - 传入的配置对象
+ * @returns {Promise<boolean>} 执行结果，true=成功，false=失败
+ */
+async function executeSubJS(subJS, settings) {
+    const logName = subJS.jsFilePath.split(/[\\/]/).filter(p => p).pop() || subJS.jsFilePath;
+
+    try {
+        log.info(`子js：${logName} 开始执行`);
+
+        // JavaScript 内置对象列表（需要排除）
+        const builtInSet = new Set([
+            'Object', 'Function', 'Array', 'String', 'Boolean', 'Number', 'Symbol', 'BigInt',
+            'Math', 'Date', 'RegExp', 'Error', 'JSON', 'Map', 'Set', 'WeakMap', 'WeakSet',
+            'Promise', 'Proxy', 'Reflect', 'ArrayBuffer', 'DataView', 'Int8Array', 'Uint8Array',
+            'Int16Array', 'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array', 'Float64Array',
+            'BigInt64Array', 'BigUint64Array', 'globalThis', 'console', 'setTimeout', 'setInterval',
+            'clearTimeout', 'clearInterval', 'parseInt', 'parseFloat', 'isNaN', 'isFinite',
+            'encodeURI', 'decodeURI', 'encodeURIComponent', 'decodeURIComponent', 'eval',
+            'Infinity', 'NaN', 'undefined', 'settings'
+        ]);
+
+        // 自动获取所有全局 API（排除内置对象，同时排除 settings 避免重复）
+        const apis = Object.keys(globalThis).filter(key => !builtInSet.has(key));
+        const values = apis.map(api => globalThis[api]);
+
+        // 创建隔离作用域的执行函数，将 settings 作为第一个参数注入
+        const execFunc = new Function('settings', ...apis, subJS.code);
+
+        const result = execFunc(settings, ...values);
+
+        // 如果返回的是 Promise，等待它完成
+        if (result && typeof result.then === 'function') {
+            await result;
+        }
+
+        log.info(`子js：${logName} 执行结束`);
+        return true;
+    } catch (e) {
+        log.error(`子js：${logName} 执行异常: ${e.message}`);
+        return false;
+    }
+}
+
+/**
+ * 执行 schedule 文件
+ * @param {string} schedulePath - schedule JSON 文件路径
+ * @returns {Promise<boolean>} 执行结果，true=全部成功，false=有任务失败
+ */
+async function executeSchedule(schedulePath) {
+    try {
+        log.info(`===== 开始执行 Schedule: ${schedulePath} =====`);
+
+        // 读取并解析 schedule 文件
+        let scheduleContent;
+        try {
+            scheduleContent = file.readTextSync(schedulePath);
+        } catch (e) {
+            log.error(`读取 schedule 文件失败: ${schedulePath}`);
+            log.error(`错误信息: ${e.message}`);
+            return false;
+        }
+
+        let scheduleData;
+        try {
+            scheduleData = JSON.parse(scheduleContent);
+        } catch (e) {
+            log.error(`解析 schedule 文件失败: ${schedulePath}`);
+            log.error(`错误信息: ${e.message}`);
+            return false;
+        }
+
+        const { schedule: actions, tasks } = scheduleData;
+
+        // 防御性检查
+        if (!actions || !Array.isArray(actions)) {
+            log.error('schedule 文件缺少 schedule 数组或格式不正确');
+            return false;
+        }
+        if (!tasks || !Array.isArray(tasks)) {
+            log.error('schedule 文件缺少 tasks 数组或格式不正确');
+            return false;
+        }
+
+        // 预加载所有任务
+        log.info(`预加载 ${tasks.length} 个任务...`);
+        const taskMap = new Map();
+        for (const task of tasks) {
+            // 检查任务配置完整性
+            if (!task.name || !task.filePath) {
+                log.error(`任务配置不完整，缺少 name 或 filePath: ${JSON.stringify(task)}`);
+                return false;
+            }
+            
+            // 根据 type 字段判断任务类型（大小写不敏感）
+            const taskTypeRaw = (task.type || 'js').toLowerCase();
+            let taskType;
+            if (taskTypeRaw === 'js') {
+                taskType = 'subJS';
+            } else if (taskTypeRaw === 'autopathing') {
+                taskType = 'pathing';
+            } else if (taskTypeRaw === 'keymousescript') {
+                taskType = 'keyMouse';
+            } else {
+                log.error(`未知的任务类型: ${task.type}`);
+                return false;
+            }
+            
+            const filePath = task.filePath;
+            log.info(`加载任务: ${task.name} (${filePath}, 类型: ${taskType})`);
+            
+            let taskInfo;
+            if (taskType === 'subJS') {
+                taskInfo = loadSubJS(filePath);
+            } else {
+                taskInfo = { filePath: filePath, type: taskType };
+            }
+            
+            taskMap.set(task.name, {
+                ...task,
+                taskType: taskType,
+                taskInfo: taskInfo
+            });
+        }
+        log.info('所有任务加载完成');
+
+        // 存储正在运行的异步任务
+        const runningTasks = new Map();
+
+        // 按顺序执行 schedule 中的每个动作
+        for (const action of actions) {
+            // 检测任务终止标志
+            try { await sleep(1); } catch (e) { 
+                log.info('检测到任务终止信号，停止执行');
+                return false; 
+            }
+
+            const { action: actionType, task: taskName, count = 1 } = action;
+
+            if (actionType === 'start') {
+                // 查找任务配置
+                const taskConfig = taskMap.get(taskName);
+                if (!taskConfig) {
+                    log.error(`未找到任务: ${taskName}`);
+                    return false;
+                }
+
+                const { taskType, taskInfo, async: isAsync, settings } = taskConfig;
+
+                // 检查异步任务是否已在运行
+                if (isAsync && runningTasks.has(taskName)) {
+                    log.warn(`任务 ${taskName} 正在执行中，不要重复启动`);
+                    continue;
+                }
+
+                // 执行指定次数
+                for (let i = 0; i < count; i++) {
+                    log.info(`执行任务: ${taskName} (第 ${i + 1}/${count} 次)`);
+
+                    let executionPromise;
+                    
+                    if (taskType === 'subJS') {
+                        executionPromise = executeSubJS(taskInfo, settings);
+                    } else if (taskType === 'pathing') {
+                        executionPromise = pathingScript.runFile(taskInfo.filePath);
+                    } else if (taskType === 'keyMouse') {
+                        executionPromise = keyMouseScript.runFile(taskInfo.filePath);
+                    } else {
+                        log.error(`未知的任务类型: ${taskType}`);
+                        return false;
+                    }
+
+                    if (isAsync) {
+                        // 异步执行，不等待完成
+                        runningTasks.set(taskName, executionPromise);
+                        log.info(`任务 ${taskName} 已异步启动`);
+                    } else {
+                        // 同步执行，等待完成
+                        const result = await executionPromise;
+                        if (taskType === 'subJS' && !result) {
+                            log.error(`任务 ${taskName} 执行失败`);
+                            return false;
+                        }
+                    }
+                }
+            } else if (actionType === 'wait') {
+                // 等待指定任务完成
+                if (runningTasks.has(taskName)) {
+                    log.info(`等待任务完成: ${taskName}`);
+                    const result = await runningTasks.get(taskName);
+                    runningTasks.delete(taskName);
+                    const taskConfig = taskMap.get(taskName);
+                    if (taskConfig && taskConfig.taskType === 'subJS' && !result) {
+                        log.error(`任务 ${taskName} 执行失败`);
+                        return false;
+                    }
+                    log.info(`任务 ${taskName} 已完成`);
+                } else {
+                    log.warn(`任务 ${taskName} 未在运行中，无需等待`);
+                }
+            } else {
+                log.error(`未知的 action 类型: ${actionType}`);
+                return false;
+            }
+        }
+
+        // 等待所有剩余的异步任务完成
+        if (runningTasks.size > 0) {
+            log.info(`等待 ${runningTasks.size} 个异步任务完成...`);
+            const taskEntries = Array.from(runningTasks.entries());
+            const promises = taskEntries.map(([_, promise]) => promise);
+            const results = await Promise.all(promises);
+            for (let i = 0; i < taskEntries.length; i++) {
+                const [name, _] = taskEntries[i];
+                if (!results[i]) {
+                    log.error(`异步任务 ${name} 执行失败`);
+                    return false;
+                }
+            }
+        }
+
+        log.info(`===== Schedule 执行完成: ${schedulePath} =====`);
+        return true;
+    } catch (e) {
+        log.error(`执行 Schedule 失败: ${e.message}`);
+        log.error(`错误堆栈: ${e.stack}`);
+        return false;
+    }
+}
+
+/**
+ * 从路线 description 中解析材料数量和时间
+ * 支持两种格式：
+ *   1. 【用时60秒，甜甜花*12，枫木*5】
+ *   2. 2个薄荷；3个日落果；11个蘑菇；（老格式，无时间）
+ * @param {string} description 路线 info.description
+ * @returns {{ declaredMaterials: Object|null, declaredDuration: number|null }}
+ */
+function parseDeclaration(description) {
+    try {
+        if (!description) return { declaredMaterials: null, declaredDuration: null };
+
+        let declaredDuration = null;
+        const declaredMaterials = {};
+
+        // 格式1: 【用时60秒，甜甜花*12】
+        const m = description.match(/【([^】]+)】/);
+        if (m) {
+            m[1].split('，').forEach(part => {
+                part = part.trim();
+                if (!part) return;
+                const tm = part.match(/^用时(\d+)秒$/);
+                if (tm) { declaredDuration = parseInt(tm[1]); return; }
+                const im = part.match(/^(.+)\*(\d+)$/);
+                if (im) { declaredMaterials[im[1].trim()] = parseInt(im[2]); }
+            });
+        } else {
+            // 格式2: 2个薄荷；3个日落果；（老格式，无时间信息）
+            const oldRe = /(\d+)个([^；\s]+)/g;
+            let match;
+            while ((match = oldRe.exec(description)) !== null) {
+                declaredMaterials[match[2].trim()] = parseInt(match[1]);
+            }
+        }
+
+        return { declaredMaterials: Object.keys(declaredMaterials).length > 0 ? declaredMaterials : null, declaredDuration };
+    } catch (e) {
+        return { declaredMaterials: null, declaredDuration: null };
+    }
+}
+
+/**
+ * 用路线声明材料数量修正拾取日志
+ * 声明中涉及的材料，其出现次数替换为声明值；未涉及的材料保留实际检测值
+ * 用于保证每日记录和优先扣减使用完整的产量，而非模板匹配漏检后的不完整数据
+ * 
+ * @param {string[]} pickupLog - 原始拾取日志（模板匹配实际命中的结果）
+ * @param {string} routeFilePath - 路线 json 文件完整路径
+ * @returns {string[]} 修正后的拾取日志（声明材料按声明值，其余保留原始值）
+ */
+function correctPickupLogByDeclaration(pickupLog, routeFilePath) {
+    try {
+        const raw = file.readTextSync(routeFilePath);
+        const json = JSON.parse(raw);
+        const dec = parseDeclaration(json.info?.description || '');
+        if (!dec.declaredMaterials) return pickupLog;
+
+        const declaredSet = new Set(Object.keys(dec.declaredMaterials));
+        // 未在声明中涉及的材料，保留原始拾取值
+        const nonDeclared = pickupLog.filter(name => !declaredSet.has(name));
+
+        // 声明材料用声明值
+        const corrected = [...nonDeclared];
+        for (const [name, count] of Object.entries(dec.declaredMaterials)) {
+            for (let i = 0; i < count; i++) {
+                corrected.push(name);
+            }
+        }
+        return corrected;
+    } catch (e) {
+        return pickupLog; // 任何异常都回退到原始日志
     }
 }

--- a/repo/js/采集cd管理/manifest.json
+++ b/repo/js/采集cd管理/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "采集cd管理",
-  "version": "2.15.1",
+  "version": "3.0.2",
   "bgi_version": "0.44.8",
   "description": "仅面对会操作文件和读readme的用户，基于文件夹操作自动管理采集路线的cd，会按照路径组的顺序依次运行，直到指定的时间，并会按照给定的cd类型，自动跳过未刷新的路线",
   "saved_files": [


### PR DESCRIPTION
1.支持将不含有import等的js作为子任务，正常纳入cd编排
2.允许地图追踪通过描述自主声明路线获取的材料数量，以适配使用莉奈娅挖矿或草神采集的情况