### PR TITLE
接入 Issue 模板与 AI 助手

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,78 +1,104 @@
-name: Bug Report / 问题反馈
-description: 反馈使用 BetterGI 脚本时遇到的问题
-title: "[Bug]: 简短描述你遇到的问题"
-labels: ["bug", "needs-triage"]
+name: Bug Report / 脚本问题反馈
+description: 反馈 BetterGI 脚本、脚本仓库或分发相关问题
+title: "[bug] "
+labels:
+  - bug
 body:
-  - type: markdown
+  - type: checkboxes
+    id: confirmations
     attributes:
-      value: |
-        请仔细填写以下信息，以便我们能快速定位并解决问题。
-        （必填项已标记）
-  
-  # BetterGI 版本 (必填)
+      label: 提交确认
+      options:
+        - label: 我已搜索现有 Issue，确认没有相同问题
+          required: true
+        - label: 我已阅读相关脚本的 README 或使用说明
+          required: true
+        - label: 我已确认问题来自脚本或脚本仓库；BetterGI 本体问题应提交到主仓库
+          required: true
+        - label: 我已移除日志、截图中的 UID、路径等隐私信息
+          required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: 涉及范围
+      options:
+        - JS 脚本
+        - 地图追踪
+        - 战斗策略
+        - 七圣召唤
+        - 脚本仓库与分发
+        - 不确定
+    validations:
+      required: true
+
   - type: input
     id: bettergi-version
     attributes:
-      label: BetterGI 版本 (必填)
-      description: 请填写你正在使用的 BetterGI 的版本号。
-      # 使用一个不存在的版本作为占位符，以便对用户进行简单验证
-      placeholder: 例如：0.53.9
+      label: BetterGI 版本号
+      placeholder: 例如：0.62.0
     validations:
       required: true
 
-  # 脚本名称 (必填)
   - type: input
     id: script-name
     attributes:
-      label: 脚本名称 (必填)
-      description: 请填写你出现问题的具体脚本的名称。
-      placeholder: 例如：自动日常, 自动锄大地 等
+      label: 相关脚本名称与版本
+      placeholder: 例如：莉奈娅挖矿一条龙 0.2.5
     validations:
       required: true
-      
-  # 问题描述 (必填)
+
+  - type: input
+    id: script-path
+    attributes:
+      label: 脚本链接或仓库路径
+      description: 填写准确路径可帮助 AI 直接读取相关源码。
+      placeholder: 例如：repo/js/LinneaMining
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: 运行环境与关键配置
+      description: Windows 版本、游戏服务器与语言、分辨率、相关脚本设置等。
+      placeholder: 请填写能够影响问题复现的环境和配置。
+    validations:
+      required: true
+
   - type: textarea
     id: problem-description
     attributes:
-      label: 问题描述 (必填)
-      description: 请清晰、简洁地描述你遇到的问题，例如“脚本执行到XX步骤后崩溃” 或 “XX功能没有按预期工作”。
-      placeholder: 请在此处具体描述遇到的问题...
+      label: 问题描述
+      placeholder: 描述实际现象、报错和影响。
     validations:
       required: true
 
-  # 复现步骤 (可选)
+  - type: textarea
+    id: expected-result
+    attributes:
+      label: 期望结果
+      placeholder: 描述正常情况下应该发生什么。
+    validations:
+      required: true
+
   - type: textarea
     id: reproduction-steps
     attributes:
-      label: 复现步骤 (可选)
-      description: 如果可能，请提供重现该问题的详细步骤。这将极大地帮助我们。
+      label: 复现步骤
       placeholder: |
-        例如：
-        1. 添加XX脚本
-        2. 设置参数 A=值, B=值
-        3. 点击“运行”
-        4. 问题发生，现象为xxx
+        1. 添加脚本……
+        2. 设置……
+        3. 运行……
     validations:
-      required: false
+      required: true
 
-  # 日志文件或录屏 (可选，并附带安全提示)
   - type: textarea
-    id: logs-and-video
+    id: logs-and-media
     attributes:
-      label: 日志文件或录屏 (可选)
-      description: |
-        请附上相关的日志文件（如 `.log` 文件）或问题发生的录屏。
-        
-        **⚠️ 重要提示:** 在上传日志、截图或录像前，请务必检查其中是否包含任何**个人敏感信息**（如用户UID等）。如果有，请将其**移除或打码**后再上传。
-      placeholder: 确认没有泄露个人信息或者UID后，你可以将文件拖动到此处完成上传
-    validations:
-      required: false
+      label: 日志、截图或录屏
+      description: 支持拖入 .log/.txt、截图或录屏，请注明发生时间，并再次确认附件中不含隐私信息。
 
-  # 其他信息（可选）
   - type: textarea
     id: additional-info
     attributes:
-      label: 其他信息 (可选)
-      description: 你认为对解决问题有帮助的任何其他信息，例如脚本版本、操作系统版本、网络环境等。
-    validations:
-      required: false
+      label: 其他信息
+      description: 如果由脚本网站跳转而来，请保留已预填的脚本作者通知信息；也可补充其他有助于定位问题的内容。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: BetterGI 文档
+    url: https://www.bettergi.com/doc.html
+    about: 使用前请先查阅 BetterGI 功能说明、快速上手和常见问题。
+  - name: 脚本贡献指南
+    url: https://bettergi.com/dev/pr.html
+    about: 提交或修改脚本前，请阅读 Pull Request 与脚本贡献说明。
+  - name: 在线脚本仓库
+    url: https://bgi.sh
+    about: 浏览、搜索和获取 BetterGI 脚本。
+  - name: BetterGI 本体 Issue
+    url: https://github.com/babalae/better-genshin-impact/issues/new/choose
+    about: BetterGI 程序本体的问题请提交到主仓库。

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,82 @@
+name: Feature Request / 功能与改进建议
+description: 提议新脚本能力、现有脚本改进或仓库分发优化
+title: "[feature] "
+labels:
+  - enhancement
+body:
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: 提交确认
+      options:
+        - label: 我已搜索现有 Issue
+          required: true
+        - label: 我已确认当前脚本或仓库尚无等价能力
+          required: true
+        - label: 该需求不仅是个人操作习惯
+          required: true
+        - label: 我理解需求可能受兼容性和维护成本限制
+          required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: 涉及范围
+      options:
+        - JS 脚本
+        - 地图追踪
+        - 战斗策略
+        - 七圣召唤
+        - 脚本仓库与分发
+        - 不确定
+    validations:
+      required: true
+
+  - type: input
+    id: script-name
+    attributes:
+      label: 相关脚本名称与版本
+
+  - type: input
+    id: script-path
+    attributes:
+      label: 脚本链接或仓库路径
+      placeholder: 例如：repo/js/LinneaMining
+
+  - type: textarea
+    id: request
+    attributes:
+      label: 需求或建议
+      placeholder: 清晰描述希望新增或改进的能力。
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: 使用场景
+      placeholder: 描述谁会在什么情况下使用，以及当前流程有什么不足。
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefits
+    attributes:
+      label: 预期收益
+      placeholder: 描述该改动能够带来的效率、稳定性或体验提升。
+    validations:
+      required: true
+
+  - type: textarea
+    id: constraints
+    attributes:
+      label: 影响与约束
+      description: 兼容性、维护成本、使用门槛；没有则填写“无”。
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: 补充信息
+      description: 可附示意图、参考实现或相关 Issue。

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,68 @@
+name: Question / 使用咨询
+description: 咨询脚本使用、配置或脚本仓库相关问题
+title: "[question] "
+labels:
+  - question
+body:
+  - type: checkboxes
+    id: confirmations
+    attributes:
+      label: 提交确认
+      options:
+        - label: 我已搜索现有 Issue
+          required: true
+        - label: 我已阅读相关脚本 README 和 BetterGI 文档
+          required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: 涉及范围
+      options:
+        - JS 脚本
+        - 地图追踪
+        - 战斗策略
+        - 七圣召唤
+        - 脚本仓库与分发
+        - 不确定
+    validations:
+      required: true
+
+  - type: input
+    id: bettergi-version
+    attributes:
+      label: BetterGI 版本号
+      placeholder: 例如：0.62.0
+
+  - type: input
+    id: script-name
+    attributes:
+      label: 相关脚本名称与版本
+
+  - type: input
+    id: script-path
+    attributes:
+      label: 脚本链接或仓库路径
+      placeholder: 例如：repo/js/LinneaMining
+
+  - type: textarea
+    id: question
+    attributes:
+      label: 问题描述
+      placeholder: 请具体说明想了解的内容。
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: 已尝试内容
+      description: 已检查的配置、文档、日志和排查结果。
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 日志与附件
+      description: 可拖入日志、截图或录屏；请先移除 UID、路径等隐私信息。

--- a/.github/repo-bot.yml
+++ b/.github/repo-bot.yml
@@ -1,0 +1,240 @@
+runtime:
+  languageMode: auto
+  dryRun: false
+
+providers:
+  openAiCompatible:
+    enabled: true
+    baseUrl: https://api.openai.com/v1
+    model: gpt-5.4
+    apiStyle: responses
+    timeoutMs: 30000
+
+issues:
+  autoProcessing:
+    skipCreatedBefore: 2026-07-31T15:00:00Z
+  titleGeneration:
+    enabled: true
+    maxLength: 100
+    detectMismatch: true
+    mismatchConfidence: 0.9
+    placeholderTitles:
+      - bug
+      - feature
+      - question
+      - issue
+      - 问题
+      - 建议
+      - 咨询
+      - 请简要描述问题
+  validation:
+    enabled: true
+    fallbackTemplateKey: bug
+    commentAnchor: issue-bot:validation
+    templates:
+      - key: bug
+        detect:
+          markers:
+            - bug
+          titlePrefixes:
+            - "[bug]"
+        requiredSections:
+          - id: scope
+            aliases:
+              - 涉及范围
+          - id: bettergi-version
+            aliases:
+              - BetterGI 版本号
+          - id: script-name
+            aliases:
+              - 相关脚本名称与版本
+          - id: environment
+            aliases:
+              - 运行环境与关键配置
+          - id: description
+            aliases:
+              - 问题描述
+          - id: expected
+            aliases:
+              - 期望结果
+          - id: steps
+            aliases:
+              - 复现步骤
+        labels:
+          whenValid:
+            - bug
+          whenInvalid:
+            - 需要更多信息
+      - key: feature
+        detect:
+          markers:
+            - feature
+          titlePrefixes:
+            - "[feature]"
+        requiredSections:
+          - id: scope
+            aliases:
+              - 涉及范围
+          - id: request
+            aliases:
+              - 需求或建议
+          - id: scenario
+            aliases:
+              - 使用场景
+          - id: benefits
+            aliases:
+              - 预期收益
+          - id: constraints
+            aliases:
+              - 影响与约束
+        labels:
+          whenValid:
+            - enhancement
+          whenInvalid:
+            - 需要更多信息
+      - key: question
+        detect:
+          markers:
+            - question
+          titlePrefixes:
+            - "[question]"
+        requiredSections:
+          - id: scope
+            aliases:
+              - 涉及范围
+          - id: question
+            aliases:
+              - 问题描述
+          - id: tried
+            aliases:
+              - 已尝试内容
+        labels:
+          whenValid:
+            - question
+          whenInvalid:
+            - 需要更多信息
+    duplicateDetection:
+      enabled: true
+      bypassLabels:
+        - 跳过重复检测
+      duplicateLabel: duplicate
+      searchResultLimit: 50
+      candidateLimit: 20
+      aiReviewMaxCandidates: 3
+      thresholds:
+        exact: 0.995
+        highConfidence: 0.93
+        reviewMin: 0.82
+      similarityComment:
+        enabled: true
+        commentAnchor: issue-bot:similar-issues
+        minScore: 0.3
+        maxCandidates: 3
+  labeling:
+    enabled: true
+    autoCreateMissing: true
+    managed:
+      - bug
+      - enhancement
+      - question
+      - 需要更多信息
+      - duplicate
+    definitions:
+      bug:
+        color: d73a4a
+        description: 脚本、仓库或分发存在缺陷或异常行为。
+      enhancement:
+        color: a2eeef
+        description: 新功能建议或现有能力改进。
+      question:
+        color: d876e3
+        description: 脚本使用、配置或仓库相关咨询。
+      需要更多信息:
+        color: fbca04
+        description: Issue 缺少定位问题所需的必要信息。
+      duplicate:
+        color: cfd3d7
+        description: 已存在相同或高度相似的问题。
+    keywordRules: []
+    aiClassification:
+      enabled: false
+      maxLabels: 3
+      minConfidence: 0.65
+      include: []
+      exclude:
+        - duplicate
+      prompt: 优先识别具体脚本类别和使用场景，不要用流程状态标签替代问题类型。
+      sourceRepository:
+        owner: babalae
+        repo: bettergi-scripts-list
+  codeContext:
+    source: github
+    includeInAiHelp: true
+    includeInFix: true
+    indexPath: repo.json
+    indexRoot: repo
+    categorySectionAliases:
+      - 涉及范围
+    nameSectionAliases:
+      - 相关脚本名称与版本
+    pathSectionAliases:
+      - 脚本链接或仓库路径
+    categoryRoots:
+      JS 脚本:
+        - repo/js
+      地图追踪:
+        - repo/pathing
+      战斗策略:
+        - repo/combat
+      七圣召唤:
+        - repo/tcg
+      脚本仓库与分发:
+        - build
+        - .github/workflows
+        - bettergi.d.ts
+      不确定:
+        - repo/js
+        - repo/pathing
+        - repo/combat
+        - repo/tcg
+        - build
+        - .github/workflows
+        - bettergi.d.ts
+  aiHelp:
+    enabled: true
+    triggerLabels: []
+    commentAnchor: issue-bot:ai
+    projectContext:
+      enabled: true
+      includeRepositoryMetadata: true
+      includeReadme: true
+      readmeMaxChars: 3000
+      profile:
+        name: BetterGI Scripts
+        aliases:
+          - BetterGI 脚本仓库
+          - bettergi-scripts-list
+        summary: BetterGI 的社区脚本索引与分发仓库，包含 JS 脚本、地图追踪、战斗策略和七圣召唤策略。
+        techStack:
+          - JavaScript
+          - JSON
+          - GitHub Actions
+  commands:
+    enabled: true
+    mentions:
+      - "@bot"
+      - "@bettergi-repo-bot"
+    access: collaborators
+    fix:
+      enabled: true
+      commentAnchor: issue-bot:fix
+    refresh:
+      enabled: true
+
+pullRequests:
+  review:
+    enabled: false
+  labeling:
+    enabled: false
+  summary:
+    enabled: false

--- a/.github/workflows/repo-bot.yml
+++ b/.github/workflows/repo-bot.yml
@@ -1,0 +1,41 @@
+name: Repo Bot
+run-name: "Repo Bot #${{ github.event.issue.number }} - ${{ github.event_name }}/${{ github.event.action }} - @${{ github.actor }}"
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  issue_comment:
+    types:
+      - created
+      - edited
+
+jobs:
+  repo-bot:
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      (
+        github.event_name != 'issue_comment' ||
+        contains(github.event.comment.body, '/fix') ||
+        contains(github.event.comment.body, '/refresh')
+      )
+    uses: ddaodan/bettergi-github-bot/.github/workflows/repo-bot.yml@v1
+    permissions:
+      issues: write
+      contents: read
+    secrets:
+      REPO_BOT_AI_API_KEY: ${{ secrets.REPO_BOT_AI_API_KEY }}
+      REPO_BOT_GITHUB_APP_PRIVATE_KEY: ${{ secrets.REPO_BOT_GITHUB_APP_PRIVATE_KEY }}
+    with:
+      config-path: .github/repo-bot.yml
+      checkout-mode: config-only
+      config-overrides-json: ${{ vars.REPO_BOT_CONFIG_OVERRIDES_JSON }}
+      ai-enabled: ${{ vars.REPO_BOT_AI_ENABLED }}
+      ai-base-url: ${{ vars.REPO_BOT_AI_BASE_URL }}
+      ai-model: ${{ vars.REPO_BOT_AI_MODEL }}
+      ai-api-style: ${{ vars.REPO_BOT_AI_API_STYLE }}
+      ai-timeout-ms: ${{ vars.REPO_BOT_AI_TIMEOUT_MS }}
+      action-ref: v1
+      github-app-id: ${{ vars.REPO_BOT_GITHUB_APP_ID }}


### PR DESCRIPTION
## 变更说明

- 重做 Bug Report 表单，并新增 Feature Request、Question 表单。
- 保留 `bug_report.yml`、`script-name`、`additional-info`，兼容脚本网站原有预填链接和作者通知。
- 关闭空白 Issue，补充 BetterGI 文档、贡献指南、脚本网站及主仓库 Issue 入口。
- 接入中央 Repo Bot 的模板校验、自动标题、重复检测、标签同步、自动 AI、`/refresh` 与 `/fix`。
- 使用滚动 `@v1` 与 `action-ref: v1`，并采用 `checkout-mode: config-only`。
- 启用 GitHub API 源码定位：显式路径优先，缺省时从 `repo.json` 按分类、展示名和版本查找。
- 使用明确截止时间 `2026-07-31T15:00:00Z`，不处理历史 Issue。

## 标签

复用 `bug`、`enhancement`、`question`、`duplicate`；新增 `需要更多信息`、`跳过重复检测`。旧模板中的 `needs-triage` 已移除。

## 验证

- 三套 Issue Forms、选择页、工作流均通过 YAML 与结构校验。
- `.github/repo-bot.yml` 已通过中央 Bot 的真实 Zod schema。
- 真实 `repo.json` 验收：`莉奈娅挖矿一条龙 0.2.5` 成功定位到 `repo/js/LinneaMining`，读取文件数量限制为 8。
- 工作流确认引用 `@v1`、`action-ref: v1`、`checkout-mode: config-only`。

## 上线说明

合并后先设置 `REPO_BOT_RUNTIME_DRY_RUN=true` 验证。目标仓库尚无 `REPO_BOT_AI_API_KEY` 与 `REPO_BOT_GITHUB_APP_PRIVATE_KEY`，需要补充后才能启用 AI Provider 与 GitHub App 身份；未配置 App 时会回退到 `GITHUB_TOKEN`。