### PR TITLE
调整 Issue 模板字段与说明

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -48,13 +48,6 @@ body:
     validations:
       required: true
 
-  - type: input
-    id: script-path
-    attributes:
-      label: 脚本链接或仓库路径
-      description: 填写准确路径可帮助 AI 直接读取相关源码。
-      placeholder: 例如：repo/js/LinneaMining
-
   - type: textarea
     id: environment
     attributes:
@@ -95,10 +88,10 @@ body:
     id: logs-and-media
     attributes:
       label: 日志、截图或录屏
-      description: 支持拖入 .log/.txt、截图或录屏，请注明发生时间，并再次确认附件中不含隐私信息。
+      description: 支持拖入 .log/.txt、截图或录屏
 
   - type: textarea
     id: additional-info
     attributes:
       label: 其他信息
-      description: 如果由脚本网站跳转而来，请保留已预填的脚本作者通知信息；也可补充其他有助于定位问题的内容。
+      description: 补充其他有助于定位问题的内容

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://www.bettergi.com/doc.html
     about: 使用前请先查阅 BetterGI 功能说明、快速上手和常见问题。
   - name: 脚本贡献指南
-    url: https://bettergi.com/dev/pr.html
+    url: https://www.bettergi.com/dev/pr.html
     about: 提交或修改脚本前，请阅读 Pull Request 与脚本贡献说明。
   - name: 在线脚本仓库
     url: https://bgi.sh

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -37,12 +37,6 @@ body:
     attributes:
       label: 相关脚本名称与版本
 
-  - type: input
-    id: script-path
-    attributes:
-      label: 脚本链接或仓库路径
-      placeholder: 例如：repo/js/LinneaMining
-
   - type: textarea
     id: request
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -39,12 +39,6 @@ body:
     attributes:
       label: 相关脚本名称与版本
 
-  - type: input
-    id: script-path
-    attributes:
-      label: 脚本链接或仓库路径
-      placeholder: 例如：repo/js/LinneaMining
-
   - type: textarea
     id: question
     attributes:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -58,5 +58,5 @@ body:
   - type: textarea
     id: logs
     attributes:
-      label: 日志与附件
-      description: 可拖入日志、截图或录屏；请先移除 UID、路径等隐私信息。
+      label: 日志、截图或录屏
+      description: 支持拖入 .log/.txt、截图或录屏


### PR DESCRIPTION
## 改动

- 从 Bug、Feature、Question 三份 Issue Forms 中移除“脚本链接或仓库路径”字段。
- 将 Bug 模板“日志、截图或录屏”的说明精简为“支持拖入 .log/.txt、截图或录屏”。
- 将 Bug 模板“其他信息”的说明调整为“补充其他有助于定位问题的内容”。
- 将 Question 模板的日志标签与说明统一为和 Bug 模板完全一致。
- 将脚本贡献指南链接修正为 `https://www.bettergi.com/dev/pr.html`。
- 保留 `script-name` 与 `additional-info` 字段 ID，确保现有预填链接继续兼容。

## 原因与影响

按最新反馈简化并统一提交表单，修正 Issue 选择页链接。移除显式路径后，AI 仍可根据脚本名称和 `repo.json` 自动定位相关脚本。

## 验证

- `git diff --check`
- 使用中央 Bot 已安装的 `js-yaml` 解析模板
- 断言三份模板均不存在 `script-path`
- 断言 Bug 与 Question 的日志标签、说明完全一致
- 断言贡献指南链接包含 `www`
- 断言兼容字段 ID 未变