### PR TITLE
fix: UID改为自身实现，同时为UID失效时添加兜底

### DIFF
--- a/repo/js/MiliastraExperiencePlayback/README.md
+++ b/repo/js/MiliastraExperiencePlayback/README.md
@@ -55,6 +55,11 @@
 - 脚本运行期间，请保持较为良好的网络环境。
 - 建议提前设置好快捷键，便于在需要时快速暂停或终止脚本。
 
+### 🗂️ 历史版本
+
+- [历史版本](https://github.com/breadgrocery/miliastra-experience-playback/tree/main/versions)
+- [更新日志](https://github.com/breadgrocery/miliastra-experience-playback/blob/main/CHANGELOG.md)
+
 ## 🐛 问题反馈
 
 [breadgrocery](https://github.com/breadgrocery/miliastra-experience-playback)

--- a/repo/js/MiliastraExperiencePlayback/libs/@bettergi+utils.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/@bettergi+utils.js
@@ -471,6 +471,7 @@ const useStore = (name) => {
   const filePath = `store/${name}.json`;
   const storeData = (() => {
     try {
+      if (file.isExists && !file.isExists(filePath)) throw new Error("File does not exist");
       if (
         ![...file.readPathSync("store")].map((path) => path.replace(/\\/g, "/")).includes(filePath)
       )

--- a/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/constants/regions.js
@@ -43,6 +43,23 @@ const findCloseDialog = () => {
 const clickToContinue = () => {
   click(960, 1070);
 };
+/** 查找UID文本 */
+const findUidText = () => {
+  const im = captureGameRegion();
+  const ro = RecognitionObject.ocr(1730, 1050, 140, 30);
+  return (() => {
+    const list = im.findMulti(ro);
+    for (let i = 0; i < list.count; i++)
+      if (list[i] && list[i].isExist()) {
+        const uid = list[i].text.replace(/\D/g, "");
+        /** 亚服 4.4 版本注册后的 UID 为 18开头的10位数字 */
+        if (uid.length >= 9) {
+          list[i].drawSelf("group_text");
+          return uid;
+        }
+      }
+  })();
+};
 /** 查找派蒙图标（判断处于奇域大世界/大厅） */
 const findPaimon = () => {
   const iro = findImageWithinBounds("assets/UI_Icon_Paimon.png", 0, 0, 100, 100, {
@@ -293,4 +310,5 @@ export {
   findSkipBtn,
   findStageEscBtn,
   findTopNSearchResultTexts,
+  findUidText,
 };

--- a/repo/js/MiliastraExperiencePlayback/libs/constants/store.js
+++ b/repo/js/MiliastraExperiencePlayback/libs/constants/store.js
@@ -1,20 +1,25 @@
+import { __name } from "../rolldown-runtime.js";
 import { getNextDay4AM, getNextMonday4AM, useStoreWithDefaults } from "../@bettergi+utils.js";
+import { findUidText } from "./regions.js";
 
 //#region src/constants/store.ts
-const uidNumber = await genshin.uid();
-if (!uidNumber) throw new Error("创建用户数据存储失败：无法识别UID");
+const DEFAULT_STORE_NAME = "default";
 /** 脚本数据存储 */
-const uid = String(uidNumber);
-const store = useStoreWithDefaults(uid, {
-  uid,
-  weekly: {
-    expGained: 0,
-    attempts: 0,
-  },
-  daily: { attempts: 0 },
-  nextWeek: getNextMonday4AM().getTime(),
-  nextDay: getNextDay4AM().getTime(),
-});
+const store = (() => {
+  const uid = findUidText() || DEFAULT_STORE_NAME;
+  if (uid === DEFAULT_STORE_NAME)
+    log.warn("无法识别 UID，已回退至默认数据存储，多用户数据存储功能将不可用");
+  return useStoreWithDefaults(uid, {
+    uid,
+    weekly: {
+      expGained: 0,
+      attempts: 0,
+    },
+    daily: { attempts: 0 },
+    nextWeek: getNextMonday4AM().getTime(),
+    nextDay: getNextDay4AM().getTime(),
+  });
+})();
 
 //#endregion
 export { store };

--- a/repo/js/MiliastraExperiencePlayback/manifest.json
+++ b/repo/js/MiliastraExperiencePlayback/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "千星奇域·经验刷取(回放通关版)",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "bgi_version": "0.61.0",
   "description": "千星奇域·经验刷取(回放通关版)",
   "authors": [


### PR DESCRIPTION
改动内容：
  - 当前`genshin.uid()`内置函数在2K分辨率及以上存在问题，修复[这几天更新后运行不了](https://github.com/breadgrocery/miliastra-experience-playback/issues/13)
  - UID识别失败时，可以使用默认数据存储继续运行（此时将失去多用户数据功能并警告），而不是拒绝执行
  - 优先使用新API，解决首次使用脚本时控制台打印不影响使用的`ReadPathSync 目录不存在`错误信息

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增 UID 自动识别功能，通过 OCR 读取游戏界面信息并初始化对应数据。
  * 无法识别 UID 时自动使用默认存储，提升首次使用时的稳定性。
  * 新增历史版本目录及更新日志链接。

* **问题修复**
  * 改进持久化文件读取逻辑，文件不存在时可正常创建并初始化存储。

* **版本更新**
  * 应用版本升级至 0.1.24。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->