### PR TITLE
fix:修复调试路线模式触发换队的bug

### DIFF
--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -75,7 +75,7 @@ const gameRegionManager = {
     if (["运行锄地路线", "启用仅指定怪物模式"].includes(operationMode)) {
         switchPartyTask = switchPartyIfNeeded(partyName);
     }
-    if (settings.disableAsync) {
+    if (settings.disableAsync && switchPartyTask) {
         const switchSuccess = await switchPartyTask;
         if (!switchSuccess) {
             log.error("队伍切换失败，脚本终止");

--- a/repo/js/AutoHoeingOneDragon/manifest.json
+++ b/repo/js/AutoHoeingOneDragon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "锄地一条龙",
-  "version": "2.11.1",
+  "version": "2.11.2",
   "description": "一站式解决自动化锄地，支持只拾取狗粮，请仔细阅读README.md后使用",
   "authors": [
     {


### PR DESCRIPTION
在勾选禁用异步操作的情况下，使用调试路线模式会导致触发换队失败