### PR TITLE
js使用地图追踪返回值确定运行结果

### DIFF
--- a/repo/js/AAA-Artifacts-Bulk-Supply/main.js
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/main.js
@@ -1333,7 +1333,8 @@ async function recognizeAndInteract() {
         gameRegion = captureGameRegion();
         let centerYF = await findFIcon();
         if (!centerYF) {
-            if (new Date() - lastRoll >= 200) {
+            // 原版拾取模式下不执行滚轮动作（拾取由 BetterGI AutoPick 完成）
+            if (pickup_Mode !== "bgi原版拾取" && new Date() - lastRoll >= 200) {
                 lastRoll = new Date();
                 if (await hasScroll()) {
                     await keyMouseScript.runFile(`assets/滚轮下翻.json`);
@@ -1366,7 +1367,8 @@ async function recognizeAndInteract() {
             */
         }
 
-        if (!foundTarget) {
+        if (!foundTarget && pickup_Mode !== "bgi原版拾取") {
+            // 原版拾取模式下不执行滚轮动作（拾取由 BetterGI AutoPick 完成）
             //log.info(`调试-执行滚轮动作`);
             const currentTime = new Date().getTime();
             if (currentTime - lastMoveDown > timeMoveUp) {

--- a/repo/js/AAA-Artifacts-Bulk-Supply/main.js
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/main.js
@@ -1360,6 +1360,8 @@ async function recognizeAndInteract() {
                 await sleep(pickupDelay);
             }
         } else {
+            // 识别失败：等待一帧，让出事件循环，避免同步紧密循环饿死 pathingTask
+            await sleep(checkDelay);
             /*
             log.info("识别失败，尝试截图");
             await refreshTargetItems(centerYF);

--- a/repo/js/AAA-Artifacts-Bulk-Supply/main.js
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/main.js
@@ -1034,9 +1034,10 @@ async function runPaths(folderFilePath, PartyName, doStop, furinaRequirement = "
             autoSalvageCount++;
         }
         const pathInfo = await parsePathing(Path.fullPath);
+        let pathRes;
         try {
             log.info(`当前进度：${Path.fileName}为${folderFilePath}第${i + 1}/${Paths.length}个`);
-            await runPath(Path.fullPath, null);
+            pathRes = await runPath(Path.fullPath, null);
             await sleep(1);
         } catch (error) {
             skiprecord = true;
@@ -1048,7 +1049,18 @@ async function runPaths(folderFilePath, PartyName, doStop, furinaRequirement = "
             success = false;
             break;
         }
-        if (pathInfo.ok) {
+        if (pathRes !== undefined) {
+            // 新版本BGI：直接使用返回值判定路线是否成功
+            if (pathRes.success) {
+                log.info("路线运行成功");
+            } else {
+                log.error(`路线运行失败：${pathRes.message}`);
+                failcount++;
+                skiprecord = true;
+                await sleep(5000);
+            }
+        } else if (pathInfo.ok) {
+            // 旧版本BGI：静默回退到坐标校验
             await genshin.returnMainUi();
             await sleep(500);
 
@@ -1245,9 +1257,16 @@ async function runPath(fullPath, targetItemPath = null) {
     const pathingTask = (async () => {
         log.info(`开始执行路线: ${fullPath}`);
         await fakeLog(fullPath, false, true, 0);
-        await pathingScript.runFile(fullPath);
+        let runRes;
+        try {
+            runRes = await pathingScript.runFile(fullPath);
+        } catch (error) {
+            log.error(`执行路线 ${fullPath} 时发生错误：${error.message}`);
+            runRes = undefined;
+        }
         await fakeLog(fullPath, false, false, 0);
         state.running = false;
+        return runRes;
     })();
 
     /* ---------- 伴随任务 ---------- */
@@ -1276,7 +1295,9 @@ async function runPath(fullPath, targetItemPath = null) {
     })();
 
     /* ---------- 并发等待 ---------- */
-    await Promise.allSettled([pathingTask, pickupTask, errorProcessTask]);
+    const results = await Promise.allSettled([pathingTask, pickupTask, errorProcessTask]);
+    // 返回地图追踪执行结果（旧版本BGI无返回值时返回 undefined）
+    return results[0].status === "fulfilled" ? results[0].value : undefined;
 }
 
 //加载拾取物图片

--- a/repo/js/AAA-Artifacts-Bulk-Supply/main.js
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/main.js
@@ -13,6 +13,7 @@ let autoSalvage = settings.autoSalvage;//启用自动分解
 let notify = settings.notify;//启用通知
 let accountName = settings.accountName || "默认账户";//账户名
 let tmThreshold = +settings.TMthreshold || 0.9;//拾取阈值
+let pickup_Mode = settings.pickup_Mode || "模板匹配拾取";//拾取模式：模板匹配拾取（脚本自行识别） / bgi原版拾取（BetterGI自动拾取触发器）
 
 //文件路径
 const DeleteButtonRo = RecognitionObject.TemplateMatch(file.ReadImageMatSync("assets/RecognitionObject/DeleteButton.png"));
@@ -66,6 +67,11 @@ let lastsettimeTime = 0;
 (async function () {
     setGameMetrics(1920, 1080, 1);
     dispatcher.AddTrigger(new RealtimeTimer("AutoSkip"));
+    if (pickup_Mode === "bgi原版拾取") {
+        // bgi原版拾取模式：物品拾取由 BetterGI AutoPick 实时触发器完成，
+        // 触发器由 setActivatePickUp 跟随 activatePickUp 开关启停（关闭时清空并恢复 AutoSkip）
+        log.info("拾取模式：bgi原版拾取（由 BetterGI AutoPick 触发器完成拾取）");
+    }
     targetItems = await loadTargetItems();
     state.activatePickUp = false;
     {
@@ -832,6 +838,23 @@ async function writeCDInfo(accountName) {
     await file.writeText(CDInfoFilePath, JSON.stringify(CDInfo), false);
 }
 
+/**
+ * 设置是否激活拾取（bgi原版拾取模式下同步启停 BetterGI AutoPick 实时触发器）
+ * - 开启（true）：添加 AutoPick 触发器，保留 AutoSkip
+ * - 关闭（false）：清除所有实时触发后重新开启 AutoSkip，防止 AutoPick 在非拾取路线误拾取
+ * 模板匹配拾取模式下无额外操作
+ */
+function setActivatePickUp(value) {
+    state.activatePickUp = value;
+    if (pickup_Mode !== "bgi原版拾取") return;
+    if (value) {
+        dispatcher.AddTrigger(new RealtimeTimer("AutoPick"));
+    } else {
+        dispatcher.clearAllTriggers();
+        dispatcher.AddTrigger(new RealtimeTimer("AutoSkip"));
+    }
+}
+
 //运行普通路线
 async function runNormalPath(doStop) {
     if (settings.fastMode) { return; }
@@ -845,9 +868,9 @@ async function runNormalPath(doStop) {
         log.info("填写了清怪队伍，执行清怪路线");
         await runPaths(normalCombatPath, combatPartyName, doStop, "black");
     }
-    state.activatePickUp = true;
+    setActivatePickUp(true);
     await runPaths(normalExecutePath, artifactPartyName, doStop, "white");
-    state.activatePickUp = false;
+    setActivatePickUp(false);
 }
 
 async function runActivatePath() {
@@ -948,10 +971,10 @@ async function runEndingAndExtraPath() {
         }
         extraPath = "";
     }
-    state.activatePickUp = true;
+    setActivatePickUp(true);
     await runPaths(endingPath, artifactPartyName, false, "white");
     await runPaths(extraPath, artifactPartyName, false, "white");
-    state.activatePickUp = false;
+    setActivatePickUp(false);
 }
 
 async function runPaths(folderFilePath, PartyName, doStop, furinaRequirement = "") {
@@ -1231,6 +1254,7 @@ async function runPath(fullPath, targetItemPath = null) {
 
     const pickupTask = (async () => {
         if (state.activatePickUp) {
+            // bgi原版拾取模式下 recognizeAndInteract 内部仅交互"调查"（拾取由 BGI AutoPick 完成）
             await recognizeAndInteract();
         }
     })();
@@ -1278,6 +1302,10 @@ async function recognizeAndInteract() {
     let lastMoveDown = 0;
 
     gameRegion = captureGameRegion();
+    // 原版拾取模式：物品拾取由 BetterGI AutoPick 完成，脚本维持交互循环但仅交互"调查"
+    const pickTargetItems = pickup_Mode === "bgi原版拾取"
+        ? targetItems.filter(it => it.itemName === "调查")
+        : targetItems;
     //主循环
     while (state.running) {
         gameRegion.dispose();
@@ -1338,7 +1366,7 @@ async function recognizeAndInteract() {
         try {
             let result;
             let itemName = null;
-            for (const targetItem of targetItems) {
+            for (const targetItem of pickTargetItems) {
                 //log.info(`正在尝试匹配${targetItem.itemName}`);
                 const cnLen = Math.min([...targetItem.itemName].filter(c => c >= '\u4e00' && c <= '\u9fff').length, 5);
                 const recognitionObject = RecognitionObject.TemplateMatch(

--- a/repo/js/AAA-Artifacts-Bulk-Supply/main.js
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/main.js
@@ -1049,7 +1049,7 @@ async function runPaths(folderFilePath, PartyName, doStop, furinaRequirement = "
             success = false;
             break;
         }
-        if (pathRes !== undefined) {
+        if (pathRes !== undefined && typeof pathRes.success === 'boolean') {
             // 新版本BGI：直接使用返回值判定路线是否成功
             if (pathRes.success) {
                 log.info("路线运行成功");

--- a/repo/js/AAA-Artifacts-Bulk-Supply/manifest.json
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "AAA狗粮批发",
-  "version": "2.5.11",
+  "version": "2.6.0",
   "tags": [
     "狗粮"
   ],

--- a/repo/js/AAA-Artifacts-Bulk-Supply/settings.json
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/settings.json
@@ -95,7 +95,7 @@
   {
     "name": "pickup_Mode",
     "type": "select",
-    "label": "选择拾取模式\n模板匹配拾取：脚本自行识别拾取（默认）\nbgi原版拾取：由 BetterGI 自动拾取触发器完成拾取（需新版 BetterGI，拾取历史不记录到本脚本）",
+    "label": "选择拾取模式",
     "options": [
       "模板匹配拾取",
       "bgi原版拾取"

--- a/repo/js/AAA-Artifacts-Bulk-Supply/settings.json
+++ b/repo/js/AAA-Artifacts-Bulk-Supply/settings.json
@@ -93,6 +93,16 @@
     "default": "100"
   },
   {
+    "name": "pickup_Mode",
+    "type": "select",
+    "label": "选择拾取模式\n模板匹配拾取：脚本自行识别拾取（默认）\nbgi原版拾取：由 BetterGI 自动拾取触发器完成拾取（需新版 BetterGI，拾取历史不记录到本脚本）",
+    "options": [
+      "模板匹配拾取",
+      "bgi原版拾取"
+    ],
+    "default": "模板匹配拾取"
+  },
+  {
     "name": "onlyActivate",
     "type": "checkbox",
     "label": "只激活收尾和额外路线，不执行\n用于联机收尾获取更高收益\n【不跑联机狗粮别勾】"

--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -1145,10 +1145,12 @@ async function runPath(fullPath, map_name, pm, pe) {
         }
 
         needRefreshCoord = true;
+        let runRes;
         try {
-            await pathingScript.runFile(fullPath);
+            runRes = await pathingScript.runFile(fullPath);
         } catch (error) {
             log.error(`执行地图追踪出现错误${error.message}`);
+            runRes = undefined;
         }
         try {
             await sleep(1);
@@ -1165,6 +1167,7 @@ async function runPath(fullPath, map_name, pm, pe) {
         }
         await fakeLog(`${fileName}`, false);
         state.running = false;
+        return runRes;
     })();
 
     /* ---------- 伴随任务 ---------- */
@@ -1398,7 +1401,7 @@ async function runPath(fullPath, map_name, pm, pe) {
     }
 
     /* ---------- 并发等待 ---------- */
-    await Promise.allSettled([
+    const results = await Promise.allSettled([
         pathingTask,
         pickupTask,
         errorProcessTask,
@@ -1406,6 +1409,8 @@ async function runPath(fullPath, map_name, pm, pe) {
         eatMedecineTask,
         dumperTask
     ].filter(Boolean));
+    // 返回地图追踪执行结果（旧版本BGI无返回值时返回 undefined）
+    return results[0].status === "fulfilled" ? results[0].value : undefined;
 }
 
 /**
@@ -1953,7 +1958,7 @@ async function processPathingsByGroup(pathings, accountName) {
             }
 
             // 调用 runPath 函数处理路径
-            await runPath(pathing.fullPath, pathing.map_name, pathing.m, pathing.e);
+            const pathRes = await runPath(pathing.fullPath, pathing.map_name, pathing.m, pathing.e);
             try {
                 await sleep(1);
             } catch (error) {
@@ -1972,24 +1977,34 @@ async function processPathingsByGroup(pathings, accountName) {
             log.info(`当前进度：第 ${targetGroup} 组第 ${groupPathCount}/${totalPathsInGroup} 个  ${pathing.fileName}已完成，该组预计剩余: ${remaininghours} 时 ${remainingminutes} 分 ${remainingseconds.toFixed(0)} 秒`);
 
             let fileEndX = 0, fileEndY = 0;
-            try {
-                const raw = file.readTextSync(pathing.fullPath);
-                const json = JSON.parse(raw);
-                if (Array.isArray(json.positions)) {
-                    for (let i = json.positions.length - 1; i >= 0; i--) {
-                        const p = json.positions[i];
-                        if (p.type !== 'orientation' &&
-                            typeof p.x === 'number' &&
-                            typeof p.y === 'number') {
-                            fileEndX = p.x;
-                            fileEndY = p.y;
-                            break;
+            let coordAbnormal = false;
+            if (pathRes !== undefined) {
+                // 新版本BGI：直接使用返回值判定路线是否成功
+                if (pathRes.success) {
+                    log.info("路线运行成功");
+                } else {
+                    log.error(`路线运行失败：${pathRes.message}`);
+                    notification.send(`路线${pathing.fileName}:路线未正常完成，不记录运行数据`);
+                    continue;
+                }
+            } else if (settings.enableCoordCheck) {
+                // 旧版本BGI：静默回退到坐标校验
+                try {
+                    const raw = file.readTextSync(pathing.fullPath);
+                    const json = JSON.parse(raw);
+                    if (Array.isArray(json.positions)) {
+                        for (let i = json.positions.length - 1; i >= 0; i--) {
+                            const p = json.positions[i];
+                            if (p.type !== 'orientation' &&
+                                typeof p.x === 'number' &&
+                                typeof p.y === 'number') {
+                                fileEndX = p.x;
+                                fileEndY = p.y;
+                                break;
+                            }
                         }
                     }
-                }
-            } catch (e) { /* 读文件失败就留 0,0 继续走后面逻辑 */ }
-            let coordAbnormal = false;
-            if (settings.enableCoordCheck) {
+                } catch (e) { /* 读文件失败就留 0,0 继续走后面逻辑 */ }
                 try {
                     await genshin.returnMainUi();
                     const miniMapPosition = await getCachedPosition(pathing.map_name, pathing.map_match_method);

--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -1171,6 +1171,26 @@ async function runPath(fullPath, map_name, pm, pe) {
     const pickupTask = (async () => {
         if (pickup_Mode.includes("模板匹配")) {
             await recognizeAndInteract();
+        } else if (pickup_Mode === "bgi原版拾取") {
+            // 原版拾取模式：拾取由 BetterGI 的 AutoPick 实时触发器完成（见 processPathingsByGroup 中的 addTimer("AutoPick")）
+            // 通过 dispatcher.getPickRecords() 周期性取回本路线的拾取历史（仅莫版拾取路径产生记录；
+            // 旧版 C# 无此方法时返回空数组/抛异常，用可选链 + try 安全降级）
+            const routePickHistory = [];
+            while (state.running) {
+                try {
+                    const records = dispatcher.getPickRecords?.() ?? [];
+                    for (const r of records) {
+                        routePickHistory.push(r);
+                        log.info(`拾取历史：${r.Name} @ ${r.Time}`);
+                    }
+                } catch (e) {
+                    break; // 旧版 C# 不支持 getPickRecords，降级停止轮询
+                }
+                await sleep(100);
+            }
+            if (routePickHistory.length > 0) {
+                log.info(`本路线拾取历史（共${routePickHistory.length}条）：${routePickHistory.map(r => r.Name).join('、')}`);
+            }
         }
     })();
 

--- a/repo/js/AutoHoeingOneDragon/main.js
+++ b/repo/js/AutoHoeingOneDragon/main.js
@@ -1978,7 +1978,7 @@ async function processPathingsByGroup(pathings, accountName) {
 
             let fileEndX = 0, fileEndY = 0;
             let coordAbnormal = false;
-            if (pathRes !== undefined) {
+            if (pathRes !== undefined && typeof pathRes.success === 'boolean') {
                 // 新版本BGI：直接使用返回值判定路线是否成功
                 if (pathRes.success) {
                     log.info("路线运行成功");

--- a/repo/js/AutoHoeingOneDragon/manifest.json
+++ b/repo/js/AutoHoeingOneDragon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "锄地一条龙",
-  "version": "2.11.1",
+  "version": "2.12.0",
   "description": "一站式解决自动化锄地，支持只拾取狗粮，请仔细阅读README.md后使用",
   "authors": [
     {

--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -1361,6 +1361,7 @@ async function handleIngredientProcessing(timeNow) {
  */
 async function executeRoute(filePath, fileName, targetObj, startTime, lastMapName, priorityItemSet) {
     state.running = true;
+    let runRes;
 
     const raw = file.readTextSync(filePath);
     const json = JSON.parse(raw);
@@ -1381,7 +1382,7 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
     const pickupTask = startPickupTask();
 
     try {
-        await pathingScript.runFile(filePath);
+        runRes = await pathingScript.runFile(filePath);
     } catch (e) {
         log.error(`路线执行失败: ${filePath}`);
         state.running = false;
@@ -1394,7 +1395,19 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
 
     /* 4-4 计算CD（掉落材料决定）*/
     const timeDiff = new Date() - startTime;
-    let pathRes = isArrivedAtEndPoint(filePath);
+    let pathRes;
+    if (runRes !== undefined) {
+        // 新版本BGI：直接使用返回值判定路线是否成功
+        if (runRes.success) {
+            log.info("路线运行成功");
+        } else {
+            log.error(`路线运行失败：${runRes.message}`);
+        }
+        pathRes = runRes.success;
+    } else {
+        // 旧版本BGI：静默回退到坐标校验
+        pathRes = isArrivedAtEndPoint(filePath);
+    }
 
     // >>> 仅当 >10s 才记录 history；若同时 pathRes === true 再更新 CD <<<
     if (timeDiff > 10000) {
@@ -1434,7 +1447,7 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
         }
     }
 
-    return { success: true, lastMapName, runPickupLog: state.runPickupLog };
+    return { success: true, lastMapName, runPickupLog: state.runPickupLog, pathRes };
 }
 
 /**
@@ -2940,7 +2953,8 @@ async function processPathGroups() {
                                         targetObj.cdTime = newTimestamp.toISOString();
                                         log.info(`schedule任务CD信息已更新，下一次可用时间为 ${newTimestamp.toLocaleString()}`);
                                     } else {
-                                        let pathRes = isArrivedAtEndPoint(filePath.fullPath);
+                                        // executeRoute 内部已用返回值或坐标校验完成路线成败判定，此处直接复用
+                                        let pathRes = routeResult.pathRes;
                                         if (pathRes) {
                                             const newTimestamp = calculateRouteCD(currentCdType, startTime);
                                             targetObj.cdTime = newTimestamp.toISOString();

--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -27,6 +27,8 @@ if (typeof rawLoop === 'boolean') {
     loopMode = 1; // 默认不循环
 }
 const disableJsons = settings.disableJsons || "";
+// 拾取模式：模板匹配拾取（JS自行识别，默认） / bgi原版拾取（由BetterGI AutoPick触发器拾取）
+let pickup_Mode;
 let processingIngredient = settings.processingIngredient;
 let findFInterval = Math.max(16, Math.min(200, parseInt(settings.findFInterval) || 100));
 let checkInterval = +settings.checkInterval || 50;
@@ -100,6 +102,15 @@ let materialCdMap = {};
 
 (async function () {
     dispatcher.AddTrigger(new RealtimeTimer("AutoSkip"));
+    // ==================== 拾取模式 ====================
+    // 模板匹配拾取：JS 自行识别拾取（默认，产量记录完整）
+    // bgi原版拾取：由 BetterGI AutoPick 实时触发器完成拾取，JS 通过 dispatcher.getPickRecords() 取回拾取记录，
+    //              记录同样写入 runPickupLog，驱动 CD 计算、历史统计、每日拾取记录与优先材料扣减
+    pickup_Mode = settings.pickup_Mode || "模板匹配拾取";
+    if (pickup_Mode === "bgi原版拾取") {
+        dispatcher.AddTrigger(new RealtimeTimer("AutoPick"));
+        log.info("拾取模式：bgi原版拾取（由 BetterGI AutoPick 触发器完成拾取）");
+    }
     // ==================== 构建 settings.json ====================
     if (!await buildSettingsJson()) {
         return;
@@ -254,6 +265,43 @@ async function recognizeAndInteract() {
             catch (e) { log.error('背包满检查异常:', e); }
             finally { checkTask = null; }
         }
+    }
+}
+
+/**
+ * 启动拾取伴随任务（随路线执行并发运行，state.running 置 false 后结束）
+ * 根据拾取模式选择：
+ * - 模板匹配拾取：JS 自行识别拾取（recognizeAndInteract）
+ * - bgi原版拾取：轮询 dispatcher.getPickRecords() 取回 BetterGI 自动拾取的记录
+ * @returns {Promise<void>} 拾取任务 Promise，应在 state.running 置 false 后 await 其结束
+ */
+function startPickupTask() {
+    if (pickup_Mode === "bgi原版拾取") {
+        return pollPickRecordsTask();
+    }
+    return recognizeAndInteract();
+}
+
+/**
+ * 轮询取回 BetterGI 莫版拾取记录（bgi原版拾取模式专用）
+ * 拾取由 AutoPick 实时触发器完成，这里周期性调用 dispatcher.getPickRecords() 取回拾取历史，
+ * 写入 state.runPickupLog，与模板匹配拾取共用同一数据通道：
+ * 后续的 CD 计算（按材料取最晚刷新）、历史统计、每日拾取记录、优先材料扣减全部复用。
+ * 旧版 C# 无 getPickRecords 时通过可选链 + try 安全降级（不报错、不记录）。
+ * @returns {Promise<void>} 一直运行直到 state.running 为 false
+ */
+async function pollPickRecordsTask() {
+    while (state.running) {
+        try {
+            const records = dispatcher.getPickRecords?.() ?? [];
+            for (const r of records) {
+                state.runPickupLog.push(r.Name);
+                log.info(`交互或拾取："${r.Name}"`);
+            }
+        } catch (e) {
+            break; // 旧版 C# 不支持 getPickRecords，降级停止轮询
+        }
+        await sleep(100);
     }
 }
 
@@ -1320,7 +1368,7 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
     // 检测是否为 schedule 文件（包含 schedule 和 tasks 字段）
     if (json.schedule && json.tasks) {
         log.info(`检测到 schedule 文件: ${fileName}，使用 schedule 模式执行`);
-        const pickupTask = recognizeAndInteract();
+        const pickupTask = startPickupTask();
         await executeSchedule(filePath);
         state.running = false;
         await pickupTask;
@@ -1330,7 +1378,7 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
     const mapName = (json.info?.map_name && json.info.map_name.trim()) ? json.info.map_name : 'Teyvat';
     await handleUnderwaterRoute(mapName, filePath, lastMapName);
     lastMapName = mapName;
-    const pickupTask = recognizeAndInteract();
+    const pickupTask = startPickupTask();
 
     try {
         await pathingScript.runFile(filePath);
@@ -2105,6 +2153,18 @@ async function buildSettingsJson() {
             "执行任务（若不存在索引文件则自动创建）",
             "重新生成索引文件（用于强制刷新CD）"
         ]
+    });
+
+    /* 5.2.0 拾取模式 */
+    newSettings.push({
+        name: "pickup_Mode",
+        type: "select",
+        label: "选择拾取模式\n推荐模板匹配拾取：脚本自行识别拾取，产量记录完整\nbgi原版拾取：由 BetterGI 自动拾取触发器完成拾取，拾取记录来自 BGI（仅莫版拾取路径产生，需新版 BetterGI 支持 getPickRecords）",
+        options: [
+            "模板匹配拾取",
+            "bgi原版拾取"
+        ],
+        default: "模板匹配拾取"
     });
 
     /* 5.2.1 循环模式 */

--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -1396,7 +1396,7 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
     /* 4-4 计算CD（掉落材料决定）*/
     const timeDiff = new Date() - startTime;
     let pathRes;
-    if (runRes !== undefined) {
+    if (runRes !== undefined && typeof runRes.success === 'boolean') {
         // 新版本BGI：直接使用返回值判定路线是否成功
         if (runRes.success) {
             log.info("路线运行成功");
@@ -1405,7 +1405,7 @@ async function executeRoute(filePath, fileName, targetObj, startTime, lastMapNam
         }
         pathRes = runRes.success;
     } else {
-        // 旧版本BGI：静默回退到坐标校验
+        // 旧版本BGI（无返回值）：静默回退到坐标校验
         pathRes = isArrivedAtEndPoint(filePath);
     }
 

--- a/repo/js/采集cd管理/main.js
+++ b/repo/js/采集cd管理/main.js
@@ -2159,7 +2159,7 @@ async function buildSettingsJson() {
     newSettings.push({
         name: "pickup_Mode",
         type: "select",
-        label: "选择拾取模式\n推荐模板匹配拾取：脚本自行识别拾取，产量记录完整\nbgi原版拾取：由 BetterGI 自动拾取触发器完成拾取，拾取记录来自 BGI（仅莫版拾取路径产生，需新版 BetterGI 支持 getPickRecords）",
+        label: "选择拾取模式",
         options: [
             "模板匹配拾取",
             "bgi原版拾取"

--- a/repo/js/采集cd管理/manifest.json
+++ b/repo/js/采集cd管理/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 1,
   "name": "采集cd管理",
-  "version": "3.0.5",
+  "version": "3.1.0",
   "bgi_version": "0.44.8",
   "description": "仅面对会操作文件和读readme的用户，基于文件夹操作自动管理采集路线的cd，会按照路径组的顺序依次运行，直到指定的时间，并会按照给定的cd类型，自动跳过未刷新的路线",
   "saved_files": [

--- a/repo/js/采集cd管理/settings.json
+++ b/repo/js/采集cd管理/settings.json
@@ -19,7 +19,7 @@
   {
     "name": "pickup_Mode",
     "type": "select",
-    "label": "选择拾取模式\n推荐模板匹配拾取：脚本自行识别拾取，产量记录完整\nbgi原版拾取：由 BetterGI 自动拾取触发器完成拾取，拾取记录来自 BGI（仅莫版拾取路径产生，需新版 BetterGI 支持 getPickRecords）",
+    "label": "选择拾取模式",
     "options": [
       "模板匹配拾取",
       "bgi原版拾取"

--- a/repo/js/采集cd管理/settings.json
+++ b/repo/js/采集cd管理/settings.json
@@ -15,5 +15,15 @@
     "name": "enableMoreSettings",
     "type": "checkbox",
     "label": "勾选后下次运行展开高级设置\n用于进行路线筛选和排序"
+  },
+  {
+    "name": "pickup_Mode",
+    "type": "select",
+    "label": "选择拾取模式\n推荐模板匹配拾取：脚本自行识别拾取，产量记录完整\nbgi原版拾取：由 BetterGI 自动拾取触发器完成拾取，拾取记录来自 BGI（仅莫版拾取路径产生，需新版 BetterGI 支持 getPickRecords）",
+    "options": [
+      "模板匹配拾取",
+      "bgi原版拾取"
+    ],
+    "default": "模板匹配拾取"
   }
 ]


### PR DESCRIPTION
## 背景

BGI 端（better-genshin-impact PR #3495）为 `pathingScript.run / runFile / runFileFromUser` 新增了执行结果返回值，JS 可直接判断地图追踪是否真正完整走完，无需再依赖"读取路线终点坐标 + 获取当前坐标 + 距离阈值"等旁路推断。

## 改动

适配以下 3 个脚本，使用新返回值确定路线运行结果：

- **采集cd管理**：`executeRoute` 使用返回值判定路线成败；路径组模式复用 `executeRoute` 返回的 `pathRes`，避免重复坐标校验
- **AAA狗粮批发**：`runPath` 透出地图追踪执行结果，调用处直接用返回值判定（失败计 `failcount` 并跳过记录）
- **锄地一条龙**：`runPath` 透出执行结果，组循环直接用返回值判定（失败发送通知并不记录运行数据）

统一判定方式：

```js
const runRes = await pathingScript.runFile(path);
if (runRes !== undefined) {
    if (runRes.success) log.info("路线运行成功");
    else log.error(`路线运行失败：${runRes.message}`);
} else {
    // 旧版本BGI（无返回值）：静默回退原有坐标校验，不输出额外日志
}
```

## 兼容性

- 旧版本 BGI 中 `runFile` 返回 `undefined`，脚本自动回退原坐标校验逻辑，行为与之前一致
- 无需修改各脚本的 `bgi_version`