### PR TITLE
fix(AutoPickLitter): 修正刷新时间以对齐北京时间

### DIFF
--- a/repo/js/AutoPickLitter/main.js
+++ b/repo/js/AutoPickLitter/main.js
@@ -635,20 +635,24 @@ async function recordForFile(judge) {
 };
 
 /* ---------- 工具函数：计算【下次4点刷新时间】 ---------- */
-async function getNextRefreshTime(lastTime) {
+function getNextRefreshTime(lastTime) {
     const now = new Date();
     // 取“最近一次已过去的 04:00”作为当前刷新周期的起点
-    const lastBoundary = new Date(now);
-    lastBoundary.setHours(4, 0, 0, 0);
-    if (now.getTime() < lastBoundary.getTime()) {
-        lastBoundary.setDate(lastBoundary.getDate() - 1);
-    };
     const ONE_DAY = 24 * 60 * 60 * 1000;
+    const SYS_OFFSET = 8 * 60 * 60 * 1000;
+    const server_now = new Date(now.getTime() + SYS_OFFSET);
+    let lastBoundary = Date.UTC(server_now.getUTCFullYear(),
+                                server_now.getUTCMonth(), 
+                                server_now.getUTCDate(),
+                                4) - SYS_OFFSET;
+    if (now.getTime() < lastBoundary) {
+        lastBoundary -= ONE_DAY;
+    };
     // lastTime 在当前周期之前 → 当前周期起点即可刷新（立即可执行）
     // lastTime 已在当前周期内 → 下次刷新为当前周期起点 + 24h
-    return lastTime.getTime() < lastBoundary.getTime()
-        ? lastBoundary.getTime()
-        : lastBoundary.getTime() + ONE_DAY;
+    return lastTime.getTime() < lastBoundary
+        ? lastBoundary
+        : lastBoundary + ONE_DAY;
 
 };
 


### PR DESCRIPTION
Fixes #3530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化每日刷新时间计算，统一按照 UTC+8 时区确定下一次刷新时间。
  - 每日凌晨 4:00 的刷新计划在不同设备和本地时区下保持一致。
  - 保持现有刷新周期和时间点语义不变，提升刷新行为的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->