### PR TITLE
fix: 容错“天地万象”首字 OCR 误识别

### DIFF
--- a/repo/js/自动领取成就奖励/main.js
+++ b/repo/js/自动领取成就奖励/main.js
@@ -38,7 +38,10 @@ async function detectTextInRegion(x, y, width, height, targetText) {
         }
         
         // 如果传入了目标文字，则进行匹配
-        if (detectedText.includes(targetText)) {
+        // OCR 偶尔会把“天地万象”首字识别为“大”，保留唯一后缀作为容错。
+        const targetMatched = detectedText.includes(targetText)
+            || (targetText === "天地" && detectedText.includes("地万象"));
+        if (targetMatched) {
             log.info(`检测到目标文字：${targetText}`);
             return detectedText;
         }


### PR DESCRIPTION
## 问题

BetterGI 0.64.0、1920×1080、OCR `V4Auto` 环境下，脚本滚动至「天地万象」时，OCR 会持续返回「大地万象」。现有逻辑只检查 `detectedText.includes("天地")`，因此无法识别已经回到首个分类，继续滚动直到 500 次循环上限。

实际日志会重复出现：

```text
检测到文字但不匹配：大地万象 (目标：天地)
```

本次运行因此在成就领取阶段空转约 27 分钟，随后才由循环上限结束。

## 修改

保留原有「天地」子串匹配，并仅在目标为「天地」时接受分类名唯一后缀「地万象」。该规则同时覆盖：

- 正常识别：`天地万象`
- 已观测误识别：`大地万象`
- 既有可容忍结果：`天地方象`

其他 OCR 目标继续使用原匹配规则。

## 影响

脚本识别到上述首字误差后可及时返回主界面，避免达到 500 次循环上限。改动只涉及「自动领取成就奖励」的分类终止判断。
