### PR TITLE
Add sleep delay before key press esc in 未指定好友时 visit function 

### DIFF
--- a/repo/js/DoubleFriendshipEncounterPoints/main.js
+++ b/repo/js/DoubleFriendshipEncounterPoints/main.js
@@ -296,6 +296,7 @@ const removedCharacters4 = typeof (settings.removedCharacters4) === 'undefined' 
 	// 好友列表递增坐标进尘歌壶(仅第一页)
 	async function RequestToVisitSereniteaPot(total_clicks) {
 		let enterStatus = false;
+		await sleep(2000);
 		keyPress("VK_ESCAPE");
 		await sleep(2000);
 		let captureRegion = captureGameRegion();


### PR DESCRIPTION
## 问题
未指定好友时，队伍切换完成后脚本立即按下 Esc，
游戏菜单尚未完成加载，导致无法正常进入好友界面。

## 修改
在打开菜单的 Esc 按键前增加 2 秒等待。

## 测试
已在未指定好友的情况下测试，能够正常打开好友界面。